### PR TITLE
Added Uninstall-Software.ps1

### DIFF
--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
@@ -1,0 +1,135 @@
+<#
+.SYNOPSIS
+    Uninstall software based on the DisplayName of said software in the registry
+.DESCRIPTION
+    This script is useful if you need to uninstall software before installing or updating other software. 
+
+    Typically best used as a pre-script in most situations.
+
+    One example use case of this script with Patch My PC's Publisher is if you have previously re-packaged software installed
+    on your devices and you need to uninstall the repackaged software, and install using the vendor's native install media 
+    (provided by the Patch My PC catalogue).
+
+    The script searches the registry for installed software, matching the supplied DisplayName value in the -DisplayName parameter
+    with that of the DisplayName in the registry. If one match is found, it uninstalls the software using the UninstallString. 
+
+    If a product code is not in the UninstallString, the whole value in UninstallString is used.
+
+    If more than one matches of the DisplayName occurs, uninstall is not possible.
+
+    If UninstallString is not present or null, uninstall is not possible.
+.PARAMETER DisplayName
+    The name of the software you wish to uninstall as it exactly appears in the registry as its DisplayName value.
+.PARAMETER Architecture
+    Choose which registry key path to search in while looking for installed software. Acceptable values are:
+        - "x86" will search in SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall on a 64-bit system.
+        - "x64" will search in SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall.
+        - "Both" will search in both key paths.
+.PARAMETER HivesToSearch
+    Choose which registry hive to search in while looking for installed software. Acceptabel values aref;
+        - "HKLM" will search in hive HKEY_LOCAL_MACHINE which is typically where system-wide installed software is registered.
+        - "HKCU" will search in hive HKEY_CURRENT_USER which is typically where user-based installed software is registered.
+.EXAMPLE
+    PS C:\> Uninstall-Software.ps1 -DisplayName "Greenshot"
+    
+    Uninstalls Greenshot if "Greenshot" is detected as the DisplayName in a key under either of the registry key paths:
+        - SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall
+        - SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall 
+#>
+param (
+    [Parameter(Mandatory)]
+    [String]$DisplayName,
+
+    [Parameter()]
+    [ValidateSet('Both', 'x86', 'x64')]
+    [string]$Architecture = 'Both',
+
+    [Parameter()]
+    [ValidateSet('HKLM', 'HKCU')]
+    [string[]]$HivesToSearch = 'HKLM'
+)
+function Get-InstalledSoftware {
+    param(
+        [Parameter()]
+        [ValidateSet('Both', 'x86', 'x64')]
+        [string]$Architecture,
+
+        [Parameter()]
+        [ValidateSet('HKLM', 'HKCU')]
+        [string[]]$HivesToSearch
+    )
+    $PathsToSearch = switch -regex ($Architecture) {
+        'Both|x86' {
+            # IntPtr will be 4 on a 32 bit system, so this add Wow6432Node if script running on 64 bit system
+            if (-not ([IntPtr]::Size -eq 4)) {
+                'Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+            }
+            # If not running on a 64 bit system then we will search for 32 bit apps in the normal software node, non-Wow6432
+            else {
+                'Software\Microsoft\Windows\CurrentVersion\Uninstall\*'
+            }
+        }
+        'Both|x64' {
+            # If we are searching for a 64 bit application then we will only search the normal software node, non-Wow6432
+            if (-not ([IntPtr]::Size -eq 4)) {
+                'Software\Microsoft\Windows\CurrentVersion\Uninstall\*'
+            }
+        }
+    }
+
+
+    $FullPaths = foreach ($PathFragment in $PathsToSearch) {
+        switch ($HivesToSearch) {
+            'HKLM' {
+                [string]::Format('registry::HKEY_LOCAL_MACHINE\{0}', $PathFragment)
+
+            }
+            'HKCU' {
+                [string]::Format('registry::HKEY_CURRENT_USER\{0}', $PathFragment)
+            }
+        }
+    }
+
+    Write-Verbose "Will search the following registry paths based on [Architecture = $Architecture] [HivesToSearch = $HivesToSearch]"
+    foreach ($RegPath in $FullPaths) {
+        Write-Verbose $RegPath
+    }
+
+    $propertyNames = 'DisplayName', 'DisplayVersion', 'PSChildName', 'Publisher', 'InstallDate', 'UninstallString'
+
+    $AllFoundObjects = Get-ItemProperty -Path $FullPaths -Name $propertyNames -ErrorAction SilentlyContinue
+
+    foreach ($Result in $AllFoundObjects) {
+        if (-not [string]::IsNullOrEmpty($Result.DisplayName)) {
+            $Result | Select-Object -Property $propertyNames
+        }
+    }
+}
+
+$InstalledSoftware = Get-InstalledSoftware -Architecture $Architecture -HivesToSearch $HivesToSearch | Where-Object DisplayName -eq $DisplayName
+
+if ($InstalledSoftware.count -gt 0) {
+    Write-Output ("Software '{0}' not installed" -f $DisplayName)
+    return 1
+}
+elseif ($InstalledSoftware.count -gt 1) {
+    Write-Output ("Found more than one instance of software '{0}', skipping because not sure which UninstallString to execute" -f $DisplayName)
+    return 1
+}
+else {
+    if ([String]::IsNullOrWhiteSpace($InstalledSoftware.UninstallString)) {
+        Write-Output ("Can not uninstall software as UninstallString is empty for '{0}'" -f $InstalledSoftware.UninstallString)
+        return 1
+    }
+    else {
+        $ProductCode = [Regex]::Match($InstalledSoftware.UninstallString, "(\{.+\})").Groups[0].Value
+        if ($ProductCode) { 
+            $proc = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x",$ProductCode,"/qn" -Wait -PassThru -ErrorAction "Stop"
+            return $proc.ExitCode
+        } 
+        else { 
+            Write-Output ("Could not parse product code from '{0}'" -f $InstalledSoftware.UninstallString)
+            return 1
+        }
+    }
+}

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/readme.md
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/readme.md
@@ -1,0 +1,98 @@
+# Uninstall-Software.ps1
+
+## SYNOPSIS
+Uninstall software based on the DisplayName of said software in the registry
+
+## SYNTAX
+
+```
+Uninstall-Software [-DisplayName] <String> [[-Architecture] <String>] [[-HivesToSearch] <String[]>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+This script is useful if you need to uninstall software before installing or updating other software. 
+
+Typically best used as a pre-script in most situations.
+
+One example use case of this script with Patch My PC's Publisher is if you have previously re-packaged software installed
+on your devices and you need to uninstall the repackaged software, and install using the vendor's native install media 
+(provided by the Patch My PC catalogue).
+
+The script searches the registry for installed software, matching the supplied DisplayName value in the -DisplayName parameter
+with that of the DisplayName in the registry.
+If one match is found, it uninstalls the software using the UninstallString. 
+
+If a product code is not in the UninstallString, the whole value in UninstallString is used.
+
+If more than one matches of the DisplayName occurs, uninstall is not possible.
+
+If UninstallString is not present or null, uninstall is not possible.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Uninstall-Software.ps1 -DisplayName "Greenshot"
+```
+
+Uninstalls Greenshot if "Greenshot" is detected as the DisplayName in a key under either of the registry key paths:
+    - SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall
+    - SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall
+
+## PARAMETERS
+
+### -DisplayName
+The name of the software you wish to uninstall as it exactly appears in the registry as its DisplayName value.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Architecture
+Choose which registry key path to search in while looking for installed software.
+Acceptable values are:
+    - "x86" will search in SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall on a 64-bit system.
+    - "x64" will search in SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall.
+    - "Both" will search in both key paths.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: Both
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HivesToSearch
+Choose which registry hive to search in while looking for installed software.
+Acceptabel values aref;
+    - "HKLM" will search in hive HKEY_LOCAL_MACHINE which is typically where system-wide installed software is registered.
+    - "HKCU" will search in hive HKEY_CURRENT_USER which is typically where user-based installed software is registered.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: HKLM
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).


### PR DESCRIPTION
## Pull Request Type

- [x] New Script
- [ ] Edit Script
- [ ] Repository Improvement

## Brief summary of changes

This script is useful if you need to uninstall software before installing or updating other software. 

Typically best used as a pre-script in most situations.

One example use case of this script with Patch My PC's Publisher is if you have previously re-packaged software installed
on your devices and you need to uninstall the repackaged software, and install using the vendor's native install media 
(provided by the Patch My PC catalogue).

## Describe your Testing

Used as a pre-script for ConfigMgr App Greenshot to uninstall a repackaged Greenshot.

## Checklist

- [x] Did you Clean your script - No environment details, comments are PG-13
- [x] Did you test your script
- [x] If required, did you create, and include a Read Me as outlined in [Community Scripts Read Me](README.MD)

## Notes for PMPC Team

Include any other generic notes for the PMPC review team here.
