### PR TITLE
Create Remove-WinZipAutorun.ps1

### DIFF
--- a/Install/Post-Install/Remove-WinZipAutorun/Remove-WinZipAutorun.ps1
+++ b/Install/Post-Install/Remove-WinZipAutorun/Remove-WinZipAutorun.ps1
@@ -1,0 +1,1 @@
+Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run","HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Run" -Name "WinZip UN" -ErrorAction "Ignore" | Remove-Item -Force


### PR DESCRIPTION
## Pull Request Type

- [X] New Script
- [ ] Edit Script
- [ ] Repository Improvement

## Brief summary of changes

Deletes registry key that causes WinZip to display an advert the first time a device restarts and logs in post install/update or WinZip

## Describe your Testing

This is intended to be used as a recommended post install script for WinZip. Tested in PMPC Lab

## Checklist

- [X] Did you Clean your script - No environment details, comments are PG-13
- [X] Did you test your script
- [X] If required, did you create, and include a Read Me as outlined in [Community Scripts Read Me](README.MD)

## Notes for PMPC Team
