### PR TITLE
Requirement rule script

### DIFF
--- a/Install/Requirement/ReaderDCx64Requirement
+++ b/Install/Requirement/ReaderDCx64Requirement
@@ -1,0 +1,8 @@
+$Value = Get-ItemProperty -Path "HKLM:\SOFTWARE\Adobe\Adobe Acrobat\DC\Installer" -Name "SCAPackageLevel" -ErrorAction SilentlyContinue
+
+if($Value.SCAPackageLevel -ne 1){
+    Write-Output "NotApplicable"
+}
+else{
+    Write-Output "Applicable"
+}


### PR DESCRIPTION
Ensures that the APPLICATION deployment for x64 Reader DC version will not try to install when Adobe Acrobat PRO is installed

## Pull Request Type

- [X ] New Script
- [ ] Edit Script
- [X ] Repository Improvement

## Brief summary of changes

Describe what you changed or added, and why you think it would be helpful to the community.

## Describe your Testing

Describe the scenario this script would be used for, and how you tested it. 

## Checklist

- [X ] Did you Clean your script - No environment details, comments are PG-13
- [ X] Did you test your script
- [X ] If required, did you create, and include a Read Me as outlined in [Community Scripts Read Me](README.MD)

## Notes for PMPC Team

Include any other generic notes for the PMPC review team here.
