### PR TITLE
Committing script to add current user to docker-users local group

### DIFF
--- a/Install/Post-Install/Docker Users Local Group/README.md
+++ b/Install/Post-Install/Docker Users Local Group/README.md
@@ -1,0 +1,5 @@
+## Add User to docker-users local group
+
+After installing Docker it is required that the current user be added to the 'docker-users' local group in order to use Docker.
+
+This script will take the current user based on the session owner of 'explorer.exe' and add to 'docker-users' group.

--- a/Install/Post-Install/Docker Users Local Group/docker_local_user.ps1
+++ b/Install/Post-Install/Docker Users Local Group/docker_local_user.ps1
@@ -1,0 +1,15 @@
+$local_group = "docker-users"
+$local_group_members = Get-LocalGroupMember -name $local_group
+
+# Getting current session user
+$currentUser = get-wmiobject win32_process -Filter "name='explorer.exe'" |
+    ForEach-Object { $_.GetOwner() } | Select-Object -Unique -Expand User
+
+# If user is not in 'docker-users' add current user
+if (!($local_group_members -contains $currentUser)){
+    Add-LocalGroupMember -Group $local_group -Member $currentUser
+}
+else {
+    write-host "$user already in group"
+    Exit
+}


### PR DESCRIPTION
## Pull Request Type

- [X] New Script

## Brief summary of changes

**Describe what you changed or added, and why you think it would be helpful to the community.**

After installing Docker it is required that the current user be added to the 'docker-users' local group in order to use Docker.

## Describe your Testing

In a 'NT authority\system' psexec session (to mimic SCCM/Software Center), was able to grab the current_user details:
```
get-wmiobject win32_process -Filter "name='explorer.exe'" |
>>     ForEach-Object { $_.GetOwner() } | Select-Object -Unique -Expand User
rlseafor
```
- $current_local_members (before adding):
```
$local_group_members

ObjectClass Name                PrincipalSource
----------- ----                ---------------
User        NT AUTHORITY\SYSTEM Unknown
```
- $local_group_members (after adding):
```
$local_group_members

ObjectClass Name                PrincipalSource
----------- ----                ---------------
User        NT AUTHORITY\SYSTEM Unknown
User        USA\rlseafor        ActiveDirectory
```

## Checklist

- [X] Did you Clean your script - No environment details, comments are PG-13
- [X] Did you test your script
- [X] If required, did you create, and include a Read Me as outlined in [Community Scripts Read Me](README.MD)
