### PR TITLE
Several new improvements to Uninstall-Software.ps1

### DIFF
--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.Tests.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.Tests.ps1
@@ -47,12 +47,12 @@ BeforeAll {
     )
 
     Mock Start-Process {}
-    Mock Invoke-Expression {}
 
     function Get-InstalledSoftware {
         # Function defined / used within the script
         # Need to define it before we can mock it with Pester
     }
+
     Mock Get-InstalledSoftware {
         param($Architecture, $HivesToSearch)
         $64HKLMMockedARPData
@@ -62,11 +62,11 @@ BeforeAll {
 Describe 'Uninstall-Software.ps1' {
     BeforeAll {
         # Use Import-Module on a .ps1 as a bit of 'tricky' to avoid the mandatory paramter but still load the internal functions
-        # The script will still run but find / do nothing
+        # The script still run but find / do nothing
         Import-Module '.\Uninstall-Software.ps1' -Force
     }
 
-    it 'will call msiexec.exe for an MSI product' {
+    it 'call msiexec.exe for an MSI product' {
         Mock Start-Process {} -Verifiable -ParameterFilter { 
             $FilePath -eq 'msiexec.exe' -and 
             $ProductCode -eq '{23170F69-40C1-2702-2201-000001000000}' 
@@ -75,7 +75,7 @@ Describe 'Uninstall-Software.ps1' {
         .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -WindowsInstaller 1 -SystemComponent 0 | Should -InvokeVerifiable
     }
 
-    it 'will call QuietUninstallString for an EXE product' {
+    it 'call QuietUninstallString for an EXE product' {
         Mock Start-Process {} -Verifiable -ParameterFilter { 
             $FilePath -eq 'C:\Program Files\7-Zip\Uninstall.exe' -and 
             $ArgumentList -eq '/S' 
@@ -84,19 +84,19 @@ Describe 'Uninstall-Software.ps1' {
         .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -WindowsInstaller 0 -SystemComponent 0 | Should -InvokeVerifiable
     }
 
-    it 'will not uninstall any software because it could not find any' {
+    it 'not uninstall any software because it could not find any' {
         .\Uninstall-Software.ps1 -DisplayName 'idonotexist' -Architecture 'x64' -HivesToSearch 'HKLM' -WindowsInstaller 1 -SystemComponent 1 | Should -Invoke -CommandName 'Start-Process' -Times 0
     }
 
-    it 'will not uninstall any software because multiple are found and -UninstallAll is not used' {
+    it 'not uninstall any software because multiple are found and -UninstallAll is not used' {
         .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' | Should -Invoke -CommandName 'Start-Process' -Times 0
     }
 
-    it 'will uninstall both MSI and EXE 7-Zip because the -UninstallAll is used' {
+    it 'uninstall both MSI and EXE 7-Zip because the -UninstallAll is used' {
         .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -UninstallAll | Should -Invoke -CommandName 'Start-Process' -Times 2
     }
 
-    it 'will only uninstall the non-visible component in ARP' {
+    it 'only uninstall the non-visible component in ARP' {
         Mock Start-Process {} -Verifiable -ParameterFilter { 
             $FilePath -eq 'msiexec.exe' -and 
             $ProductCode -eq '{FF4D5F84-0CFF-4865-8395-51445340F429}' 
@@ -104,7 +104,7 @@ Describe 'Uninstall-Software.ps1' {
         .\Uninstall-Software.ps1 -DisplayName 'Zscaler' -Architecture 'x64' -HivesToSearch 'HKLM' -WindowsInstaller 1 -SystemComponent 1 | Should -InvokeVerifiable
     }
 
-    it 'will only uninstall the visible component in ARP' {
+    it 'only uninstall the visible component in ARP' {
         Mock Start-Process {} -Verifiable -ParameterFilter { 
             $FilePath -eq 'C:\Program Files\Zscaler\ZSAInstaller\uninstall.exe' -and 
             $ArgumentList -eq '/S' 
@@ -112,7 +112,7 @@ Describe 'Uninstall-Software.ps1' {
         .\Uninstall-Software.ps1 -DisplayName 'Zscaler' -Architecture 'x64' -HivesToSearch 'HKLM' -WindowsInstaller 0 -SystemComponent 0 -AdditionalArguments '/S' | Should -InvokeVerifiable
     }
 
-    it 'will uninstall both MSI and EXE 7-Zip because the -UninstallAll with -AdditionalArguments is used' {
+    it 'uninstall both MSI and EXE 7-Zip because the -UninstallAll with -AdditionalArguments is used' {
         Mock Start-Process {} -Verifiable -ParameterFilter { 
             $FilePath -eq 'msiexec.exe' -and 
             $ProductCode -eq '{23170F69-40C1-2702-2201-000001000000}' -and 
@@ -129,7 +129,7 @@ Describe 'Uninstall-Software.ps1' {
         .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -UninstallAll -AdditionalArguments '/FakeParameter' | Should -InvokeVerifiable
     }
 
-    it 'will uninstall both MSI and EXE 7-Zip because the -UninstallAll with -AdditionalMSIArguments and -AdditionalEXEArguments is used' {
+    it 'uninstall both MSI and EXE 7-Zip because the -UninstallAll with -AdditionalMSIArguments and -AdditionalEXEArguments is used' {
         Mock Start-Process {} -Verifiable -ParameterFilter { 
             $FilePath -eq 'msiexec.exe' -and 
             $ProductCode -eq '{23170F69-40C1-2702-2201-000001000000}' -and 
@@ -146,11 +146,11 @@ Describe 'Uninstall-Software.ps1' {
         .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -UninstallAll -AdditionalEXEArguments '/FakeParameter' -AdditionalMSIArguments 'MSIRMSHUTDOWN=0' | Should -InvokeVerifiable
     }
 
-    it 'will verify parameter set validation for -AdditionalArguments, -AdditionalEXEArguments, and -AdditionalMSIArguments' {
+    it 'verify parameter set validation for -AdditionalArguments, -AdditionalEXEArguments, and -AdditionalMSIArguments' {
         { .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -AdditionalArguments '/FakeParameter' -AdditionalEXEArguments '/FakeParameter' -AdditionalMSIArguments 'MSIRMSHUTDOWN=0' } | Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
     }
 
-    it 'will validate Split-UninstallString correctly parses the UninstallString' -TestCases @(
+    it 'validate Split-UninstallString correctly parses UninstallString: <UninstallString>' -TestCases @(
         @{ UninstallString = '"C:\Program Files\7-Zip\Uninstall.exe" /S /abc /whatever';         Expected = @('C:\Program Files\7-Zip\Uninstall.exe', '/S /abc /whatever') },
         @{ UninstallString = 'C:\Program Files\7-Zip\Uninstall.exe /S';                          Expected = @('C:\Program Files\7-Zip\Uninstall.exe', '/S') },
         @{ UninstallString = 'C:\Program Files\7-Zip.exe.exe\Uninstall.exe /S /abc /whatever';   Expected = @('C:\Program Files\7-Zip.exe.exe\Uninstall.exe', '/S /abc /whatever') },
@@ -177,7 +177,7 @@ Describe 'Uninstall-Software.ps1' {
         }
     }
 
-    it 'will throw if notepad.exe is already running and specified as -ProcessName' {
+    it 'throw if notepad.exe is already running and specified as -ProcessName' {
         Mock Get-Process { 
             [PSCustomObject]@{ Name = 'notepad' }
         }
@@ -185,12 +185,54 @@ Describe 'Uninstall-Software.ps1' {
         { .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -ProcessName 'notepad' } | Should -Throw -ExceptionType ([System.InvalidOperationException]) -ExpectedMessage "Process 'notepad' is already running before the uninstallation has even started, quitting"
     }
 
-    it 'should call Wait-Process' {
+    it 'should call Wait-Process if notepad.exe is running and specified as -ProcessName' {
         Mock Get-Process {}
         Mock Wait-Process {} -Verifiable -ParameterFilter {
             $Name -eq 'notepad'
         }
 
         .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -WindowsInstaller 0 -ProcessName 'notepad' | Should -Invoke -CommandName 'Wait-Process' -Times 1
+    }
+
+    it '<Action> software because it is <Operator> than <Version>' -TestCases @(
+        @{ Action = 'not uninstall'; Operator = 'greater than'; Version = '22.01' },
+        @{ Action = 'not uninstall'; Operator = 'less than';    Version = '21.01' },
+        @{ Action = 'not uninstall'; Operator = 'equal to';     Version = '1.0'   },
+        @{ Action = 'uninstall';     Operator = 'greater than'; Version = '20.01' },
+        @{ Action = 'uninstall';     Operator = 'less than';    Version = '22.01' },
+        @{ Action = 'uninstall';     Operator = 'equal to';     Version = '21.01' }
+    ) {
+        $Splat = @{
+            DisplayName      = '7-Zip*'
+            Architecture     = 'x64'
+            HivesToSearch    = 'HKLM'
+            WindowsInstaller = 0
+        }
+
+        switch ($Operator) {
+            'greater than' { $Splat['VersionGreaterThan'] = $Version }
+            'less than'    { $Splat['VersionLessThan']    = $Version }
+            'equal to'     { $Splat['VersionEqualTo']     = $Version }
+        }
+
+        $Times = if ($Action -eq 'uninstall') { 1 } else { 0 }
+
+        .\Uninstall-Software.ps1 @Splat | Should -Invoke -CommandName 'Start-Process' -Times $Times
+    }
+
+    it 'not uninstall any software because it is not greater than 22.01 and less than 20.01' {
+        .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -VersionGreaterThan '22.01' -VersionLessThan '20.01' | Should -Invoke -CommandName 'Start-Process' -Times 0
+    }
+
+    it 'not uninstall any software because it is not greater than 22.01 and less than 21.01 and equal to 21.0' {
+        .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -VersionGreaterThan '22.01' -VersionLessThan '21.01' -VersionEqualTo '21.0' | Should -Invoke -CommandName 'Start-Process' -Times 0
+    }
+
+    it 'uninstall software because it is greater than 20.00 and less than 22.00' {
+        .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -WindowsInstaller 0 -VersionGreaterThan '20.0' -VersionLessThan '22.0' | Should -Invoke -CommandName 'Start-Process' -Times 1
+    }
+
+    it 'uninstall software because it is greater than 20.00 and less than 22.00 and equal to 21.01' {
+        .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -WindowsInstaller 0 -VersionGreaterThan '20.0' -VersionLessThan '22.0' -VersionEqualTo '21.01' | Should -Invoke -CommandName 'Start-Process' -Times 1
     }
 }

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.Tests.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.Tests.ps1
@@ -176,4 +176,21 @@ Describe 'Uninstall-Software.ps1' {
             $Result[1] | Should -Be $Expected[1]
         }
     }
+
+    it 'will throw if notepad.exe is already running and specified as -ProcessName' {
+        Mock Get-Process { 
+            [PSCustomObject]@{ Name = 'notepad' }
+        }
+
+        { .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -ProcessName 'notepad' } | Should -Throw -ExceptionType ([System.InvalidOperationException]) -ExpectedMessage "Process 'notepad' is already running before the uninstallation has even started, quitting"
+    }
+
+    it 'should call Wait-Process' {
+        Mock Get-Process {}
+        Mock Wait-Process {} -Verifiable -ParameterFilter {
+            $Name -eq 'notepad'
+        }
+
+        .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -WindowsInstaller 0 -ProcessName 'notepad' | Should -Invoke -CommandName 'Wait-Process' -Times 1
+    }
 }

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
@@ -1,4 +1,3 @@
-function abc123 {
 <#
 .SYNOPSIS
     Uninstall software based on the DisplayName of said software in the registry
@@ -527,4 +526,3 @@ else {
 }
 
 $null = Stop-Transcript
-}

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
@@ -31,13 +31,15 @@ function abc123 {
     The name of the software you wish to uninstall as it appears in the registry as its DisplayName value. * wildcard supported.
 .PARAMETER Architecture
     Choose which registry key path to search in while looking for installed software. Acceptable values are:
-        - "x86" will search in SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall on a 64-bit system.
-        - "x64" will search in SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall.
-        - "Both" will search in both key paths.
+
+    - "x86" will search in SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall on a 64-bit system.
+    - "x64" will search in SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall.
+    - "Both" will search in both key paths.
 .PARAMETER HivesToSearch
-    Choose which registry hive to search in while looking for installed software. Acceptabel values aref;
-        - "HKLM" will search in hive HKEY_LOCAL_MACHINE which is typically where system-wide installed software is registered.
-        - "HKCU" will search in hive HKEY_CURRENT_USER which is typically where user-based installed software is registered.
+    Choose which registry hive to search in while looking for installed software. Acceptable values are:
+
+    - "HKLM" will search in hive HKEY_LOCAL_MACHINE which is typically where system-wide installed software is registered.
+    - "HKCU" will search in hive HKEY_CURRENT_USER which is typically where user-based installed software is registered.
 .PARAMETER WindowsInstaller
     Specify a value between 1 and 0 to use as an additional criteria when trying to find installed software.
 
@@ -98,8 +100,9 @@ function abc123 {
     PS C:\> Uninstall-Software.ps1 -DisplayName "Greenshot"
     
     Uninstalls Greenshot if "Greenshot" is detected as the DisplayName in a key under either of the registry key paths:
-        - SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall
-        - SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall 
+
+    - SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall
+    - SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall 
 .EXAMPLE
     PS C:\> Uninstall-Software.ps1 -DisplayName "Mozilla*"
 

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
@@ -190,22 +190,6 @@ function Split-UninstallString {
         [String]$UninstallString
     )
 
-    # Example UninstallStrings:
-    # "C:\Program Files\7-Zip\Uninstall.exe" /S /abc /whatever
-    # C:\Program Files\7-Zip\Uninstall.exe /S
-    # C:\Program Files\7-Zip.exe.exe\Uninstall.exe /S /abc /whatever
-    # "C:\Program Files\7-Zip.exe.exe\Uninstall.exe" /S /abc /whatever
-    # C:\Program Files\7-Zip.exe\Uninstall.exe.exe /S /abc /whatever
-    # "C:\Program Files\7-Zip.exe\Uninstall.exe.exe" /S /abc /whatever
-    # C:\Program Files\7-Zip\Uninstall.exe.exe /S /abc /whatever
-    # "C:\Program Files\7-Zip\Uninstall.exe.exe" /S /abc /whatever
-    # C:\Program Files\7-Zip\Uninstall.exe
-    # "C:\Program Files\7-Zip\Uninstall.exe"
-    # C:\Program Files\7-Zip\Uninstall.exe.exe
-    # "C:\Program Files\7-Zip\Uninstall.exe.exe"
-    # C:\Program Files\7-Zip.exe\Uninstall.exe
-    # "C:\Program Files\7-Zip.exe\Uninstall.exe"
-
     if ($UninstallString.StartsWith('"')) {
         [Int]$EndOfFilePath = [String]::Join('', $UninstallString[1..$UninstallString.Length]).IndexOf('"')
         [String]$FilePath   = [String]::Join('', $UninstallString[0..$EndOfFilePath]).Trim(' ','"')
@@ -263,7 +247,7 @@ function Uninstall-Software {
 
             $StartProcessSplat = @{
                 FilePath     = 'msiexec.exe'
-                ArgumentList = '/x', $ProductCode, '/qn', 'REBOOT=ReallySuppress', '/l*v {0}' -f $MsiLog
+                ArgumentList = '/x', $ProductCode, '/qn', 'REBOOT=ReallySuppress', ('/l*v {0}' -f $MsiLog)
                 Wait         = $true
                 PassThru     = $true
                 ErrorAction  = $ErrorActionPreference

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/readme.md
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/readme.md
@@ -10,7 +10,7 @@ Uninstall software based on the DisplayName of said software in the registry
 Uninstall-Software.ps1 -DisplayName <String> [-Architecture <String>] [-HivesToSearch <String[]>] [-WindowsInstaller <Int32>]
  [-SystemComponent <Int32>] [-VersionLessThan <Version>] [-VersionEqualTo <Version>]
  [-VersionGreaterThan <Version>] [-AdditionalArguments <String>] [-UninstallAll] [-ProcessName <String>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ### AdditionalEXEorMSIArguments
@@ -18,7 +18,7 @@ Uninstall-Software.ps1 -DisplayName <String> [-Architecture <String>] [-HivesToS
 Uninstall-Software.ps1 -DisplayName <String> [-Architecture <String>] [-HivesToSearch <String[]>] [-WindowsInstaller <Int32>]
  [-SystemComponent <Int32>] [-VersionLessThan <Version>] [-VersionEqualTo <Version>]
  [-VersionGreaterThan <Version>] [-AdditionalMSIArguments <String>] [-AdditionalEXEArguments <String>]
- [-UninstallAll] [-ProcessName <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [-UninstallAll] [-ProcessName <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -57,8 +57,8 @@ Uninstall-Software.ps1 -DisplayName "Greenshot"
 ```
 
 Uninstalls Greenshot if "Greenshot" is detected as the DisplayName in a key under either of the registry key paths:
-    - SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall
-    - SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall
+- SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall
+- SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall
 
 ### EXAMPLE 2
 ```
@@ -113,9 +113,10 @@ Accept wildcard characters: False
 ### -Architecture
 Choose which registry key path to search in while looking for installed software.
 Acceptable values are:
-    - "x86" will search in SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall on a 64-bit system.
-    - "x64" will search in SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall.
-    - "Both" will search in both key paths.
+
+- "x86" will search in SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall on a 64-bit system.
+- "x64" will search in SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall.
+- "Both" will search in both key paths.
 
 ```yaml
 Type: String
@@ -130,10 +131,10 @@ Accept wildcard characters: False
 ```
 
 ### -HivesToSearch
-Choose which registry hive to search in while looking for installed software.
-Acceptabel values aref;
-    - "HKLM" will search in hive HKEY_LOCAL_MACHINE which is typically where system-wide installed software is registered.
-    - "HKCU" will search in hive HKEY_CURRENT_USER which is typically where user-based installed software is registered.
+Choose which registry hive to search in while looking for installed software. Acceptable values are;
+
+- "HKLM" will search in hive HKEY_LOCAL_MACHINE which is typically where system-wide installed software is registered.
+- "HKCU" will search in hive HKEY_CURRENT_USER which is typically where user-based installed software is registered.
 
 ```yaml
 Type: String[]
@@ -325,21 +326,6 @@ The .exe extension is not required, and the process name is case-insensitive.
 Type: String
 Parameter Sets: (All)
 Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ProgressAction
-{{ Fill ProgressAction Description }}
-
-```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: proga
 
 Required: False
 Position: Named

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/readme.md
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/readme.md
@@ -5,10 +5,20 @@ Uninstall software based on the DisplayName of said software in the registry
 
 ## SYNTAX
 
+### AdditionalArguments (Default)
 ```
-Uninstall-Software [-DisplayName] <String> [[-Architecture] <String>] [[-HivesToSearch] <String[]>]
- [[-WindowsInstaller] <Int32>] [[-SystemComponent] <Int32>] [[-AdditionalArguments] <String>] [-UninstallAll]
- [<CommonParameters>]
+Uninstall-Software.ps1 -DisplayName <String> [-Architecture <String>] [-HivesToSearch <String[]>] [-WindowsInstaller <Int32>]
+ [-SystemComponent <Int32>] [-VersionLessThan <Version>] [-VersionEqualTo <Version>]
+ [-VersionGreaterThan <Version>] [-AdditionalArguments <String>] [-UninstallAll] [-ProcessName <String>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+### AdditionalEXEorMSIArguments
+```
+Uninstall-Software.ps1 -DisplayName <String> [-Architecture <String>] [-HivesToSearch <String[]>] [-WindowsInstaller <Int32>]
+ [-SystemComponent <Int32>] [-VersionLessThan <Version>] [-VersionEqualTo <Version>]
+ [-VersionGreaterThan <Version>] [-AdditionalMSIArguments <String>] [-AdditionalEXEArguments <String>]
+ [-UninstallAll] [-ProcessName <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -22,13 +32,22 @@ on your devices and you need to uninstall the repackaged software, and install u
 
 The script searches the registry for installed software, matching the supplied DisplayName value in the -DisplayName parameter
 with that of the DisplayName in the registry.
-If one match is found, it uninstalls the software using the UninstallString. 
+If one match is found, it uninstalls the software using the QuietUninstallString or UninstallString.
 
-If a product code is not in the UninstallString, the whole value in QuietUninstallString is used, or just UninstallString if QuietUninstallString doesn't exist.
+You can supply additional arguments to the uninstaller using the -AdditionalArguments, -AdditionalMSIArguments, or -AdditionalEXEArguments parameters.
 
-If more than one matches of the DisplayName occurs, uninstall is not possible.
+You cannot use -AdditionalArguments with -AdditionalMSIArguments or -AdditionalEXEArguments.
+
+If a product code is not in the UninstallString, QuietUninstallString or UninstallString are used.
+QuietUninstallString is preferred if it exists.
+
+If more than one matches of the DisplayName occurs, uninstall is not possible unless you use the -UninstallAll switch.
 
 If QuietUninstallString and UninstallString is not present or null, uninstall is not possible.
+
+A log file is created in the temp directory with the name "Uninstall-Software-\<DisplayName\>.log" which contains the verbose output of the script.
+
+An .msi log file is created in the temp directory with the name "\<DisplayName\>_\<DisplayVersion\>.msi.log" which contains the verbose output of the msiexec.exe process.
 
 ## EXAMPLES
 
@@ -48,6 +67,31 @@ Uninstall-Software.ps1 -DisplayName "Mozilla*"
 
 Uninstalls any products where DisplayName starts with "Mozilla"
 
+### EXAMPLE 3
+```
+Uninstall-Software.ps1 -DisplayName "*SomeSoftware*" -AdditionalMSIArguments "/quiet /norestart" -AdditionalEXEArguments "/S" -UninstallAll
+```
+
+Uninstalls all software where DisplayName contains "SomeSoftware". 
+
+For any software found in the registry matching the search criteria and are MSI-based (WindowsInstaller = 1), "/quiet /norestart" will be supplied to the uninstaller.
+
+For any software found in the registry matching the search criteria and  are EXE-based (WindowsInstaller = 0 or non-existent), "/S" will be supplied to the uninstaller.
+
+### EXAMPLE 4
+```
+Uninstall-Software.ps1 -DisplayName "KiCad*" -ProcessName "Un_A"
+```
+
+Uninstalls KiCad and waits for the process "Un_A" to finish after the uninstallation has started.
+
+### EXAMPLE 5
+```
+Uninstall-Software.ps1 -DisplayName "SomeSoftware" -VersionGreaterThan 1.0.0
+```
+
+Uninstalls SomeSoftware if the version is greater than 1.0.0
+
 ## PARAMETERS
 
 ### -DisplayName
@@ -60,7 +104,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 1
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -79,7 +123,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 2
+Position: Named
 Default value: Both
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -97,7 +141,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: Named
 Default value: HKLM
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -120,7 +164,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: Named
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -137,8 +181,59 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: Named
 Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -VersionLessThan
+Specify a version number to use as an additional criteria when trying to find installed software.
+
+This parameter can be used in conjuction with -VersionEqualTo and -VersionGreaterThan.
+
+```yaml
+Type: Version
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -VersionEqualTo
+Specify a version number to use as an additional criteria when trying to find installed software.
+
+This parameter can be used in conjuction with -VersionLessThan and -VersionGreaterThan.
+
+```yaml
+Type: Version
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -VersionGreaterThan
+Specify a version number to use as an additional criteria when trying to find installed software.
+
+This parameter can be used in conjuction with -VersionLessThan and -VersionEqualTo.
+
+```yaml
+Type: Version
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -150,11 +245,11 @@ Cannot be used with -AdditionalMSIArguments or -AdditionalEXEArguments.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: AdditionalArguments
 Aliases:
 
 Required: False
-Position: 6
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -162,18 +257,18 @@ Accept wildcard characters: False
 
 ### -AdditionalMSIArguments
 A string which includes the additional parameters you would like passed to the MSI uninstaller. 
-    
+
 This is useful if you use this, and (or not at all) -AdditionalEXEArguments, in conjuction with -UninstallAll to apply different parameters for MSI based uninstalls.
 
 Cannot be used with -AdditionalArguments.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: AdditionalEXEorMSIArguments
 Aliases:
 
 Required: False
-Position: 7
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -181,18 +276,18 @@ Accept wildcard characters: False
 
 ### -AdditionalEXEArguments
 A string which includes the additional parameters you would like passed to the EXE uninstaller.
-    
+
 This is useful if you use this, and (or not at all) -AdditionalMSIArguments, in conjuction with -UninstallAll to apply different parameters for EXE based uninstalls.
 
 Cannot be used with -AdditionalArguments.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: AdditionalEXEorMSIArguments
 Aliases:
 
 Required: False
-Position: 8
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -213,6 +308,42 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProcessName
+Wait for this process to finish after the uninstallation has started.
+
+If the process is already running before the uninstallation has even started, the script will quit with an error.
+
+This is useful for some software which spawn a seperate process to do the uninstallation, and the main process exits before the uninstallation is finished.
+
+The .exe extension is not required, and the process name is case-insensitive.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
New functionality for `Uninstall-Software.ps1`:

- MSI based software now call `/l*v` by default. 
  - The log name will be `$env:temp\$DisplayName_$DisplayVersion.msi.log`
- New parameters to apply additional search criteria based on Displayjversion: `-VersionLessThan`, `-VersionEqualTo`, `-VersionGreaterThan`
- New parameter to allow additional process tracking if uninstallers call seperate processes: `-ProcessName`
  - After calling the `UninstallString`, the script waits for 5 seconds and then checks to see if the process name given is running
  - If it is, the script tracks and waits for the process, for a maximum of 30 minutes (hardcoded timeout value)
  - If it isn't, the script resumes as normally
- The script now correctly waits for processes where the software being removed is of type EXE (now uses `Start-Process` instead of `Invoke-Expression`, see `Split-UninstallString` for argument handling.)
- Clearer logging
- 8 new tests added to `Uninstall-Software.Tests.ps1` for new functionality
