### PR TITLE
Array casted to string for .msi log file name

### DIFF
--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
@@ -289,7 +289,10 @@ function Uninstall-Software {
         if ($ProductCode) { 
             Write-Verbose ('Found product code, will uninstall using "{0}"' -f $ProductCode)
 
-            $MsiLog = '{0}\{1}_{2}.msi.log' -f $env:temp, $Software.DisplayName.Replace(' ','_'), $Software.DisplayVersion.Split([System.IO.Path]::GetInvalidFileNameChars()) -join ''
+            $MsiLog = '{0}\{1}_{2}.msi.log' -f 
+                $env:temp, 
+                [String]::Join('', $Software.DisplayName.Replace(' ','_').Split([System.IO.Path]::GetInvalidFileNameChars())), 
+                [String]::Join('', $Software.DisplayVersion.Split([System.IO.Path]::GetInvalidFileNameChars()))
 
             $StartProcessSplat = @{
                 FilePath     = 'msiexec.exe'


### PR DESCRIPTION
The .msi log file name incorrectly contained `System.String[]` in the name instead of the product's display version.