### PR TITLE
Exception handling is useless on non-English OS

### DIFF
--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
@@ -365,8 +365,8 @@ function Uninstall-Software {
                 Wait-Process -Name $UninstallProcessName -Timeout 1800 -ErrorAction 'Stop'
             }
             catch {
-                if ($_.Exception.Message -match 'Cannot find a process with the name') {
-                    Write-Verbose $_.Exception.Message.Replace('Verify the process name and call the cmdlet again.')
+                if ($_.FullyQualifiedErrorId -match 'NoProcessFoundForGivenName') {
+                    Write-Verbose 'Process not found, continuing'
                 }
                 else {
                     throw


### PR DESCRIPTION
Improves error handling to not independent of language OS; `FullyQualifiedErrorId` is helpfully populated in the `ErrorRecord` object by `Wait-Process` and is consistent outside of English OS:

![image](https://github.com/PatchMyPCTeam/Community-Scripts/assets/6683266/a927f9c3-4f29-4e5b-a2bb-42841a9ebee1)
