### PR TITLE
Refactor Uninstall-Software.ps1

### DIFF
--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.Tests.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.Tests.ps1
@@ -1,4 +1,6 @@
 BeforeAll {
+    Push-Location $PSScriptRoot
+
     $64HKLMMockedARPData = @(
         [PSCustomObject]@{
             DisplayName = '7-Zip 22.01 (x64 edition)'
@@ -48,15 +50,9 @@ BeforeAll {
 
     Mock Start-Process {}
 
-    function Get-InstalledSoftware {
-        # Function defined / used within the script
-        # Need to define it before we can mock it with Pester
-    }
-
-    Mock Get-InstalledSoftware {
-        param($Architecture, $HivesToSearch)
+    Mock Get-ItemProperty {
         $64HKLMMockedARPData
-    } -ParameterFilter { $Architecture -eq 'x64' -and $HivesToSearch -eq 'HKLM' }
+    }
 }
 
 Describe 'Uninstall-Software.ps1' {
@@ -235,4 +231,8 @@ Describe 'Uninstall-Software.ps1' {
     it 'uninstall software because it is greater than 20.00 and less than 22.00 and equal to 21.01' {
         .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -WindowsInstaller 0 -VersionGreaterThan '20.0' -VersionLessThan '22.0' -VersionEqualTo '21.01' | Should -Invoke -CommandName 'Start-Process' -Times 1
     }
+}
+
+AfterAll {
+    Pop-Location
 }

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.Tests.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.Tests.ps1
@@ -50,7 +50,7 @@ BeforeAll {
 
     Mock Start-Process {}
 
-    Mock Get-ItemProperty {
+    Mock Get-ItemProperty -ParameterFilter { $Path -eq 'registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall\*' } {
         $64HKLMMockedARPData
     }
 }

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
@@ -220,10 +220,13 @@ function Get-InstalledSoftware {
 
             }
             'HKCU' {
-                [string]::Format('registry::HKEY_CURRENT_USER\{0}', $PathFragment)
+                # There is no Wow6432Node Uninstall key for HKEY_CURRENT_USER
+                [string]::Format('registry::HKEY_CURRENT_USER\{0}', $PathFragment.Replace('\Wow6432Node',''))
             }
         }
     }
+    # Remove duplicate created when -Architecture Both|x86 -HivesToSearch HKCU,HKLM is used
+    $FullPaths = $FullPaths | Select-Object -Unique
 
     Write-Verbose "Will search the following registry paths based on [Architecture = $Architecture] [HivesToSearch = $HivesToSearch]"
     foreach ($RegPath in $FullPaths) {

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
@@ -220,13 +220,10 @@ function Get-InstalledSoftware {
 
             }
             'HKCU' {
-                # There is no Wow6432Node Uninstall key for HKEY_CURRENT_USER
-                [string]::Format('registry::HKEY_CURRENT_USER\{0}', $PathFragment.Replace('\Wow6432Node',''))
+                [string]::Format('registry::HKEY_CURRENT_USER\{0}', $PathFragment)
             }
         }
     }
-    # Remove duplicate created when -Architecture Both|x86 -HivesToSearch HKCU,HKLM is used
-    $FullPaths = $FullPaths | Select-Object -Unique
 
     Write-Verbose "Will search the following registry paths based on [Architecture = $Architecture] [HivesToSearch = $HivesToSearch]"
     foreach ($RegPath in $FullPaths) {

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
@@ -240,7 +240,7 @@ function Get-InstalledSoftware {
     foreach ($Result in $AllFoundObjects) {
         try {
             if ($Result.DisplayName -notlike $DisplayName) {
-                Write-Verbose ('Skipping {0} as name does not match {1}' -f $Result.DisplayName, $DisplayName)
+                #Write-Verbose ('Skipping {0} as name does not match {1}' -f $Result.DisplayName, $DisplayName)
                 continue
             }
             # Casting to [bool] will return $false if the property is 0 or not present


### PR DESCRIPTION
## Pull Request Type

- [ ] New Script
- [x] Edit Script
- [ ] Repository Improvement

## Brief summary of changes

Refactored to make it easier to read and also easier to add additional filters planned for a forthcoming update.

WindowsInstaller and SystemComponent are now booleans to avoid having to validate integer ranges. Also casting the registry value to [bool] gives us $false when empty, so less logic required to compare.

Filter options now splatted to Get-InstalledSoftware which now does the filtering inside the function.

Registry paths tweaked so that HKCU paths will not look under Wow6432Node. Also previous code appeared that it would return duplicate apps on a 32-bit machine, and hence try to uninstall twice.

ConvertTo-Version function added to better handle non-standard version numbers and ensure 1.0 is equal to 1.0.0 etc.

Edit: also includes the work noted here: https://github.com/PatchMyPCTeam/Community-Scripts/pull/58

## Describe your Testing

Tested a variety of uninstalls using all the various filtering options and combinations. Checked existing usage of this script in SupportedProducts.xml to make sure all existing usage catered for.

Pester tests have been changed to mock Get-ItemProperty instead of Get-InstalledSoftware, and all tests are still passing.
## Checklist

- [x] Did you Clean your script - No environment details, comments are PG-13
- [x] Did you test your script
- [x] If required, did you create, and include a Read Me as outlined in [Community Scripts Read Me](README.MD)

## Notes for PMPC Team

This is a general refactor to make it easier to include some further upcoming changes.
