### PR TITLE
New parameter -EnforcedArguments

### DIFF
--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.Tests.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.Tests.ps1
@@ -150,6 +150,15 @@ Describe 'Uninstall-Software.ps1' {
         { .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -AdditionalArguments '/FakeParameter' -AdditionalEXEArguments '/FakeParameter' -AdditionalMSIArguments 'MSIRMSHUTDOWN=0' } | Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
     }
 
+    it 'uninstall EXE 7-Zip with -EnforcedArguments' {
+        Mock Start-Process {} -Verifiable -ParameterFilter { 
+            $FilePath -eq 'C:\Program Files\7-Zip\Uninstall.exe' -and 
+            $ArgumentList -eq '/EnforcedParameter'
+        }
+
+        .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -WindowsInstaller 0 -EnforcedArguments '/EnforcedParameter' | Should -InvokeVerifiable
+    }
+
     it 'validate Split-UninstallString correctly parses UninstallString: <UninstallString>' -TestCases @(
         @{ UninstallString = '"C:\Program Files\7-Zip\Uninstall.exe" /S /abc /whatever';         Expected = @('C:\Program Files\7-Zip\Uninstall.exe', '/S /abc /whatever') },
         @{ UninstallString = 'C:\Program Files\7-Zip\Uninstall.exe /S';                          Expected = @('C:\Program Files\7-Zip\Uninstall.exe', '/S') },

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
@@ -65,6 +65,12 @@
     Specify a version number to use as an additional criteria when trying to find installed software.
 
     This parameter can be used in conjuction with -VersionLessThan and -VersionEqualTo.
+.PARAMETER EnforcedArguments
+    A string which includes the arguments you would like passed to the uninstaller.
+
+    Cannot be used with -AdditionalArguments, -AdditionalMSIArguments, or -AdditionalEXEArguments.
+
+    This will not be used for .msi based software uninstalls.
 .PARAMETER AdditionalArguments
     A string which includes the additional parameters you would like passed to the uninstaller.
 
@@ -122,6 +128,10 @@
     PS C:\> Uninstall-Software.ps1 -DisplayName "SomeSoftware" -VersionGreaterThan 1.0.0
 
     Uninstalls SomeSoftware if the version is greater than 1.0.0
+.EXAMPLE
+    PS C:\> Uninstall-Software.ps1 -DisplayName "AnyDesk" -EnforcedArguments "--remove --silent"
+
+    Uninstalls AnyDesk with the enforced arguments "--remove --silent", instead of using the default parameters in the UninstallString.
 #>
 [CmdletBinding(DefaultParameterSetName = 'AdditionalArguments')]
 param (
@@ -152,6 +162,9 @@ param (
 
     [Parameter()]
     [Version]$VersionGreaterThan,
+
+    [Parameter(ParameterSetName = 'EnforcedArguments')]
+    [String]$EnforcedArguments,
 
     [Parameter(ParameterSetName = 'AdditionalArguments')]
     [String]$AdditionalArguments,
@@ -266,6 +279,9 @@ function Uninstall-Software {
         [PSCustomObject]$Software,
 
         [Parameter()]
+        [String]$EnforcedArguments,
+
+        [Parameter()]
         [String]$AdditionalArguments,
 
         [Parameter()]
@@ -286,6 +302,7 @@ function Uninstall-Software {
     }
     else {
         $ProductCode = [Regex]::Match($Software.UninstallString, "^msiexec.+(\{.+\})", 'IgnoreCase').Groups[1].Value
+
         if ($ProductCode) { 
             Write-Verbose ('Found product code, will uninstall using "{0}"' -f $ProductCode)
 
@@ -342,6 +359,10 @@ function Uninstall-Software {
                 Write-Verbose ('Adding additional EXE arguments "{0}" to UninstallString' -f $AdditionalEXEArguments)
                 $Arguments = "{0} {1}" -f $Arguments, $AdditionalEXEArguments
             }
+            elseif (-not [String]::IsNullOrWhiteSpace($EnforcedArguments)) {
+                Write-Verbose ('Using enforced arguments "{0}" instead of those in UninstallString' -f $EnforcedArguments)
+                $Arguments = $EnforcedArguments
+            }
 
             if (-not [String]::IsNullOrWhiteSpace($Arguments)) {
                 $StartProcessSplat['ArgumentList'] = $Arguments.Trim()
@@ -385,6 +406,7 @@ $null = Start-Transcript -Path $log -Append -NoClobber -Force
 $VerbosePreference = 'Continue'
 
 $UninstallSoftwareSplat = @{
+    EnforcedArguments      = $EnforcedArguments
     AdditionalArguments    = $AdditionalArguments
     AdditionalMSIArguments = $AdditionalMSIArguments
     AdditionalEXEArguments = $AdditionalEXEArguments

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/readme.md
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/readme.md
@@ -7,18 +7,27 @@ Uninstall software based on the DisplayName of said software in the registry
 
 ### AdditionalArguments (Default)
 ```
-Uninstall-Software.ps1 -DisplayName <String> [-Architecture <String>] [-HivesToSearch <String[]>] [-WindowsInstaller <Int32>]
- [-SystemComponent <Int32>] [-VersionLessThan <Version>] [-VersionEqualTo <Version>]
- [-VersionGreaterThan <Version>] [-AdditionalArguments <String>] [-UninstallAll] [-ProcessName <String>]
- [<CommonParameters>]
+Uninstall-Software.ps1 -DisplayName <String> [-Architecture <String>] [-HivesToSearch <String[]>]
+ [-WindowsInstaller <Int32>] [-SystemComponent <Int32>] [-VersionLessThan <Version>]
+ [-VersionEqualTo <Version>] [-VersionGreaterThan <Version>] [-AdditionalArguments <String>] [-UninstallAll]
+ [-ProcessName <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+### EnforcedArguments
+```
+Uninstall-Software.ps1 -DisplayName <String> [-Architecture <String>] [-HivesToSearch <String[]>]
+ [-WindowsInstaller <Int32>] [-SystemComponent <Int32>] [-VersionLessThan <Version>]
+ [-VersionEqualTo <Version>] [-VersionGreaterThan <Version>] [-EnforcedArguments <String>] [-UninstallAll]
+ [-ProcessName <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### AdditionalEXEorMSIArguments
 ```
-Uninstall-Software.ps1 -DisplayName <String> [-Architecture <String>] [-HivesToSearch <String[]>] [-WindowsInstaller <Int32>]
- [-SystemComponent <Int32>] [-VersionLessThan <Version>] [-VersionEqualTo <Version>]
- [-VersionGreaterThan <Version>] [-AdditionalMSIArguments <String>] [-AdditionalEXEArguments <String>]
- [-UninstallAll] [-ProcessName <String>] [<CommonParameters>]
+Uninstall-Software.ps1 -DisplayName <String> [-Architecture <String>] [-HivesToSearch <String[]>]
+ [-WindowsInstaller <Int32>] [-SystemComponent <Int32>] [-VersionLessThan <Version>]
+ [-VersionEqualTo <Version>] [-VersionGreaterThan <Version>] [-AdditionalMSIArguments <String>]
+ [-AdditionalEXEArguments <String>] [-UninstallAll] [-ProcessName <String>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -57,6 +66,7 @@ Uninstall-Software.ps1 -DisplayName "Greenshot"
 ```
 
 Uninstalls Greenshot if "Greenshot" is detected as the DisplayName in a key under either of the registry key paths:
+
 - SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall
 - SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall
 
@@ -91,6 +101,13 @@ Uninstall-Software.ps1 -DisplayName "SomeSoftware" -VersionGreaterThan 1.0.0
 ```
 
 Uninstalls SomeSoftware if the version is greater than 1.0.0
+
+### EXAMPLE 6
+```
+Uninstall-Software.ps1 -DisplayName "AnyDesk" -EnforcedArguments "--remove --silent"
+```
+
+Uninstalls AnyDesk with the enforced arguments "--remove --silent", instead of using the default parameters in the UninstallString.
 
 ## PARAMETERS
 
@@ -131,7 +148,8 @@ Accept wildcard characters: False
 ```
 
 ### -HivesToSearch
-Choose which registry hive to search in while looking for installed software. Acceptable values are;
+Choose which registry hive to search in while looking for installed software.
+Acceptable values are:
 
 - "HKLM" will search in hive HKEY_LOCAL_MACHINE which is typically where system-wide installed software is registered.
 - "HKCU" will search in hive HKEY_CURRENT_USER which is typically where user-based installed software is registered.
@@ -239,6 +257,25 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -EnforcedArguments
+A string which includes the arguments you would like passed to the uninstaller.
+
+Cannot be used with -AdditionalArguments, -AdditionalMSIArguments, or -AdditionalEXEArguments.
+
+This will not be used for .msi based software uninstalls.
+
+```yaml
+Type: String
+Parameter Sets: EnforcedArguments
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -AdditionalArguments
 A string which includes the additional parameters you would like passed to the uninstaller.
 
@@ -326,6 +363,21 @@ The .exe extension is not required, and the process name is case-insensitive.
 Type: String
 Parameter Sets: (All)
 Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
 
 Required: False
 Position: Named


### PR DESCRIPTION
## Pull Request Type

- [ ] New Script
- [x] Edit Script
- [ ] Repository Improvement

## Brief summary of changes

New parameter `-EnforcedArguments`; in scenarios where you don't want to use the parameters in (Quiet)UninstallString, but still need to call the referenced binary uninstaller, this parameter lets you specify a hardcorded scalar string of parameters.

## Describe your Testing

Existing Pester tests still pass and added a new test case "uninstall EXE 7-Zip with -EnforcedArguments" to cover the new functionality

## Checklist

- [x] Did you Clean your script - No environment details, comments are PG-13
- [x] Did you test your script
- [x] If required, did you create, and include a Read Me as outlined in [Community Scripts Read Me](README.MD)

## Notes for PMPC Team

👋 
