### PR TITLE
Revert WindowInstaller and SystemComponent to Int

### DIFF
--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
@@ -150,10 +150,12 @@ param (
     [String[]]$HivesToSearch = 'HKLM',
 
     [Parameter()]
-    [Boolean]$WindowsInstaller,
+    [ValidateSet(1, 0)]
+    [Int]$WindowsInstaller,
 
     [Parameter()]
-    [Boolean]$SystemComponent,
+    [ValidateSet(1, 0)]
+    [Int]$SystemComponent,
 
     [Parameter()]
     [String]$VersionLessThan,
@@ -200,10 +202,12 @@ function Get-InstalledSoftware {
         [String[]]$HivesToSearch = 'HKLM',
 
         [Parameter()]
-        [Boolean]$WindowsInstaller,
+        [ValidateSet(1, 0)]
+        [Int]$WindowsInstaller,
     
         [Parameter()]
-        [Boolean]$SystemComponent,
+        [ValidateSet(1, 0)]
+        [Int]$SystemComponent,
     
         [Parameter()]
         [String]$VersionLessThan,
@@ -258,13 +262,14 @@ function Get-InstalledSoftware {
                 #Write-Verbose ('Skipping {0} as name does not match {1}' -f $Result.DisplayName, $DisplayName)
                 continue
             }
-            # Casting to [bool] will return $false if the property is 0 or not present
-            if ($PSBoundParameters.ContainsKey('WindowsInstaller') -and [bool]$Result.WindowsInstaller -ne $WindowsInstaller) {
-                Write-Verbose ('Skipping {0} as WindowsInstaller value {1} does not match {2}' -f [bool]$Result.DisplayName, $Result.WindowsInstaller, $WindowsInstaller)
+            # Casting to [bool] will return $false if the registry property is 0 or not present, and can also cast integers 0/1 to $false/$true.
+            # Function accepts integers however, as supplying 1 for an expected bool works within powershell, but not on a powershell.exe command line.
+            if ($PSBoundParameters.ContainsKey('WindowsInstaller') -and [bool]$Result.WindowsInstaller -ne [bool]$WindowsInstaller) {
+                Write-Verbose ('Skipping {0} as WindowsInstaller value {1} does not match {2}' -f $Result.DisplayName, $Result.WindowsInstaller, $WindowsInstaller)
                 continue
             }
-            if ($PSBoundParameters.ContainsKey('SystemComponent') -and [bool]$Result.SystemComponent -ne $SystemComponent) {
-                Write-Verbose ('Skipping {0} as SystemComponent value {1} does not match {2}' -f [bool]$Result.DisplayName, $Result.SystemComponent, $SystemComponent)
+            if ($PSBoundParameters.ContainsKey('SystemComponent') -and [bool]$Result.SystemComponent -ne [bool]$SystemComponent) {
+                Write-Verbose ('Skipping {0} as SystemComponent value {1} does not match {2}' -f $Result.DisplayName, $Result.SystemComponent, $SystemComponent)
                 continue
             }
             if ($PSBoundParameters.ContainsKey('VersionEqualTo') -and (ConvertTo-Version $Result.DisplayVersion) -ne (ConvertTo-Version $VersionEqualTo)) {


### PR DESCRIPTION
## Pull Request Type

- [ ] New Script
- [x] Edit Script
- [ ] Repository Improvement

## Brief summary of changes

Previous changes switched WindowsInstaller and SystemComponent from integers to booleans. Booleans accept 0 and 1, but not when wrapped in quotes. Integers are fine with parsing strings as numbers however.

This previous implementation worked fine if executing the script from inside an existing powershell session, but not on a a powershell.exe command line, where `-WindowsInstaller 1` somehow gets interpreted as a string of "1".

The 2 parameters have been changed back to integers. They are later cast to booleans for the comparison with the registry value.

## Describe your Testing

Existing Pester test passes, plus tested various combinations of WindowsInstaller and SystemComponent flags via PatchMyPC Publisher and ScriptRunner.

## Checklist

- [x] Did you Clean your script - No environment details, comments are PG-13
- [x] Did you test your script
- [x] If required, did you create, and include a Read Me as outlined in [Community Scripts Read Me](README.MD)

## Notes for PMPC Team

cnv_n6cdm1b
