### PR TITLE
Remove default asterisk on display name like operator

### DIFF
--- a/Install/NotInstalledRequirement/Get-NotInstalledRequirement.ps1
+++ b/Install/NotInstalledRequirement/Get-NotInstalledRequirement.ps1
@@ -84,7 +84,7 @@ function Get-InstalledSoftware {
             $displayName = (Get-ItemProperty -Path $subkey.PSPath -Name DisplayName -ErrorAction SilentlyContinue).DisplayName
 
             foreach ($app in $appName) {
-                if ($displayName -like "*$app*") {
+                if ($displayName -like "$app") {
 
                     # Gather additional information when a match is found
                     $displayVersion = (Get-ItemProperty -Path $subkey.PSPath -Name DisplayVersion -ErrorAction SilentlyContinue).DisplayVersion

--- a/Install/NotInstalledRequirement/ReadMe.md
+++ b/Install/NotInstalledRequirement/ReadMe.md
@@ -4,7 +4,8 @@
 
 Searches for installed software by DisplayName and returns 'Applicable' if not found.  
 
-Created on:   2024-06-17  
+Created on:   2024-06-17
+Updated on:   2024-08-22
 Created by:   Ben Whitmore @PatchMyPC  
 Filename:     Get-NotInstalledRequirement.ps1  
 
@@ -23,6 +24,8 @@ Author/Maintainer: [@Codaamok](https://github.com/codaamok)
 
 You will need to modify the array variable at the top of the script to specify the app(s) you want to check for. If the apps are found, the script will return nothing, and the requirement will not be met. If the apps are not found, the script will return 'Applicable' and the requirement will be met.  
 
+> **Note**: The script will search for the exact match based on what you enter in $appNameList. You can add asterisk characters (*) if you want to use wildcards.
+
 ### Example 1
 
 ```powershell
@@ -34,6 +37,11 @@ You will need to modify the array variable at the top of the script to specify t
 ```powershell
 [array]$appNameList = @('Google Chrome')
 ````
+
+### Example 3
+```powershell
+[array]$appNameList = @('Google*')
+```
 
 ## Further Testing
 You can uncomment line 105 to see the results of the search using the $appNameList array. Dont forget to comment it out again before using the script in Intune.  


### PR DESCRIPTION
## Pull Request Type

- [ ] New Script
- [x] Edit Script
- [ ] Repository Improvement

## Brief summary of changes

Get-NotInstalledRequirement.ps1 by default suffixed and prefixed asterisk characters to the display comparison comparison - this in undesirable in some situations.

This change forces the user to update the string array on line 32 in `$appNameList` if they want to include asterisk characters or not.

## Describe your Testing

Describe the scenario this script would be used for, and how you tested it. 

## Checklist

- [ ] Did you Clean your script - No environment details, comments are PG-13
- [ ] Did you test your script
- [ ] If required, did you create, and include a Read Me as outlined in [Community Scripts Read Me](README.MD)

## Notes for PMPC Team

Include any other generic notes for the PMPC review team here.
