### PR TITLE
Add RemovePath parameter

### DIFF
--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
@@ -105,7 +105,7 @@
 
     The .exe extension is not required, and the process name is case-insensitive.
 .PARAMETER RemovePath
-    Supply a list of files and folders to be removed after the uninstallations have been processed. Use with -Force if all items are to be removed even if there is no software found to be uninstalled.
+    Supply a list of files and folders to be removed after the uninstallations have been processed. Use with -Force if all items are to be removed even if there is no software found to be uninstalled or if errors are encountered during uninstallation.
 .EXAMPLE
     PS C:\> Uninstall-Software.ps1 -DisplayName "Greenshot"
     

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/readme.md
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/readme.md
@@ -371,6 +371,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RemovePath
+Supply a list of files and folders to be removed after the uninstallations have been processed.
+
+Use with -Force if all items are to be removed even if there is no software found to be uninstalled or if errors are encountered during uninstallation.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ProgressAction
 {{ Fill ProgressAction Description }}
 


### PR DESCRIPTION
## Pull Request Type

- [ ] New Script
- [x] Edit Script
- [ ] Repository Improvement

## Brief summary of changes

New parameter RemovePath provided. This can take an array of files or folders to be deleted after uninstall has complete. Default behaviour is as follows:

- If any errors are encountered during uninstall, or there was no software found to uninstall, by default nothing is removed unless -Force is specified.
- If script finds multiple software entries and UninstallAll was not supplied, the script normally exits; in this case nothing is removed, even if -Force is specified.
- Paths are only removed if they exist, and errors are caught and output as warnings.

## Describe your Testing
Multiple uninstall scenarios tested out, both successful and failing cases, with either single or multiple files/folders supplied.

## Checklist

- [x] Did you Clean your script - No environment details, comments are PG-13
- [x] Did you test your script
- [x] If required, did you create, and include a Read Me as outlined in [Community Scripts Read Me](README.MD)

## Notes for PMPC Team

Include any other generic notes for the PMPC review team here.
