### PR TITLE
Allow "All" for -WindowsInstaller parameter

### DIFF
--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.Tests.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.Tests.ps1
@@ -273,6 +273,20 @@ Describe 'Uninstall-Software.ps1' {
 
         .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -WindowsInstaller 1 -Force | Should -Be 0
     }
+
+    it 'verify all exe and msi software is uninstalled when using -UninstallAll and -WindowsInstaller "All"' {
+        Mock Start-Process {} -Verifiable -ParameterFilter { 
+            $FilePath -eq 'msiexec.exe' -and 
+            $ProductCode -eq '{23170F69-40C1-2702-2201-000001000000}' 
+        }
+
+        Mock Start-Process {} -Verifiable -ParameterFilter { 
+            $FilePath -eq 'C:\Program Files\7-Zip\Uninstall.exe' -and 
+            $ArgumentList -eq '/S' 
+        }
+
+        .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -WindowsInstaller 'All' -UninstallAll | Should -Invoke -CommandName 'Start-Process' -Times 2
+    }
 }
 
 AfterAll {

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.Tests.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.Tests.ps1
@@ -285,7 +285,7 @@ Describe 'Uninstall-Software.ps1' {
             $ArgumentList -eq '/S' 
         }
 
-        .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -WindowsInstaller 'All' -UninstallAll | Should -Invoke -CommandName 'Start-Process' -Times 2
+        .\Uninstall-Software.ps1 -DisplayName '7-Zip*' -Architecture 'x64' -HivesToSearch 'HKLM' -WindowsInstaller 'Both' -UninstallAll | Should -Invoke -CommandName 'Start-Process' -Times 2
     }
     
     Context 'RemovePath parameter tests' {

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
@@ -40,15 +40,15 @@
     - "HKLM" will search in hive HKEY_LOCAL_MACHINE which is typically where system-wide installed software is registered.
     - "HKCU" will search in hive HKEY_CURRENT_USER which is typically where user-based installed software is registered.
 .PARAMETER WindowsInstaller
-    Specify a value between 1 and 0 to use as an additional criteria when trying to find installed software.
+    Acceptable string values are: "0", "1" and "Both" - these are used as an additional criteria when trying to find installed software.
 
-    If WindowsInstaller registry value has a data of 1, it generally means software was installed from MSI.
+    If the WindowsInstaller registry value has a data of 1, it generally means software was installed from MSI. 
+    
+    If the registry value is 0 (not common), or not present at all (more common), it generally means software was installed from an EXE.
 
-    Omitting the parameter entirely or specify a value of 0 generally means software was installed from EXE
+    Specifying a value of 0 will look for software where WindowsInstaller is equal to 0, or not present at all. 
 
-    This is useful to be more specific about software titles you want to uninstall.
-
-    Specifying a value of 0 will look for software where WindowsInstaller is equal to 0, or not present at all.
+    Alternatively, if you specify "Both", the script will look for software where WindowsInstaller is either not present, 0, or 1.
 .PARAMETER SystemComponent
     Specify a value between 1 and 0 to use as an additional criteria when trying to find installed software.
 
@@ -137,6 +137,10 @@
     PS C:\> Uninstall-Software.ps1 -DisplayName "AnyDesk" -EnforcedArguments "--remove --silent"
 
     Uninstalls AnyDesk with the enforced arguments "--remove --silent", instead of using the default parameters in the UninstallString.
+.EXAMPLE
+    PS C:\> Uninstall-Software.ps1 -DisplayName "VLC Media Player*" -WindowsInstaller "Both" -AdditionalEXEArguments "/S" -UninstallAll
+
+    Uninstalls all instances of VLC Media Player, whether it was installed from an MSI or an EXE, and supplies "/S" to the uninstaller if it was installed with an EXE.
 #>
 [CmdletBinding(DefaultParameterSetName = 'AdditionalArguments')]
 param (
@@ -152,7 +156,7 @@ param (
     [String[]]$HivesToSearch = 'HKLM',
 
     [Parameter()]
-    [ValidateSet('1', '0', 'All')]
+    [ValidateSet('1', '0', 'Both')]
     [String]$WindowsInstaller = '0',
 
     [Parameter()]
@@ -207,7 +211,7 @@ function Get-InstalledSoftware {
         [String[]]$HivesToSearch = 'HKLM',
 
         [Parameter()]
-        [ValidateSet('1', '0', 'All')]
+        [ValidateSet('1', '0', 'Both')]
         [String]$WindowsInstaller,
     
         [Parameter()]
@@ -269,7 +273,7 @@ function Get-InstalledSoftware {
             }
 
             switch ($WindowsInstaller) {
-                'All' {
+                'Both' {
                     # Do nothing
                 }
                 '1' {

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/readme.md
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/readme.md
@@ -109,6 +109,13 @@ Uninstall-Software.ps1 -DisplayName "AnyDesk" -EnforcedArguments "--remove --sil
 
 Uninstalls AnyDesk with the enforced arguments "--remove --silent", instead of using the default parameters in the UninstallString.
 
+### EXAMPLE 7
+```
+Uninstall-Software.ps1 -DisplayName "VLC Media Player*" -WindowsInstaller "Both" -AdditionalEXEArguments "/S" -UninstallAll
+```
+
+Uninstalls all instances of VLC Media Player, whether it was installed from an MSI or an EXE, and supplies "/S" to the uninstaller if it was installed with an EXE.
+
 ## PARAMETERS
 
 ### -DisplayName
@@ -167,15 +174,15 @@ Accept wildcard characters: False
 ```
 
 ### -WindowsInstaller
-Specify a value between 1 and 0 to use as an additional criteria when trying to find installed software.
+Acceptable string values are: "0", "1" and "Both" - these are used as an additional criteria when trying to find installed software.
 
-If WindowsInstaller registry value has a data of 1, it generally means software was installed from MSI.
+If the WindowsInstaller registry value has a data of 1, it generally means software was installed from MSI. 
 
-Omitting the parameter entirely or specify a value of 0 generally means software was installed from EXE
+If the registry value is 0 (not common), or not present at all (more common), it generally means software was installed from an EXE.
 
-This is useful to be more specific about software titles you want to uninstall.
+Specifying a value of 0 will look for software where WindowsInstaller is equal to 0, or not present at all. 
 
-Specifying a value of 0 will look for software where WindowsInstaller is equal to 0, or not present at all.
+Alternatively, if you specify "Both", the script will look for software where WindowsInstaller is either not present, 0, or 1.
 
 ```yaml
 Type: Int32


### PR DESCRIPTION
## Pull Request Type

- [ ] New Script
- [x] Edit Script
- [ ] Repository Improvement

## Brief summary of changes

This enables people to uninstall either EXE or MSI software (or all/both if detected and used `-UninstallAll`) via `-WindowsInstaller 'All'`.

Previously, people needed to call the script twice if they wanted to remove EXE and MSI software - one with specifying 1 and the other 0 for the `-WindowsInstaller` parameter.

## Describe your Testing

Added new Pester tests, and existing tests still pass.

As an aside, changing the object type of `-WindowsInstaller` from int to string does not impact powershell.exe - I tested this. I know this is a consideration when used with PatchMyPC-ScriptRunner.exe or other automation tools which may called the script from powershell.exe.

![image](https://github.com/user-attachments/assets/d6897c80-b731-4b5d-aa2f-4c121a5b62d2)

## Checklist

- [x] Did you Clean your script - No environment details, comments are PG-13
- [x] Did you test your script
- [x] If required, did you create, and include a Read Me as outlined in [Community Scripts Read Me](README.MD)

## Notes for PMPC Team

pls review and approve :) 
