### PR TITLE
Improve read me windows installer param

### DIFF
--- a/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/Uninstall-Software.ps1
@@ -40,13 +40,8 @@
     - "HKLM" will search in hive HKEY_LOCAL_MACHINE which is typically where system-wide installed software is registered.
     - "HKCU" will search in hive HKEY_CURRENT_USER which is typically where user-based installed software is registered.
 .PARAMETER WindowsInstaller
-    Specify a value between 1 and 0 to use as an additional criteria when trying to find installed software.
-
-    If WindowsInstaller registry value has a data of 1, it generally means software was installed from MSI.
-
-    Omitting the parameter entirely or specify a value of 0 generally means software was installed from EXE
-
-    This is useful to be more specific about software titles you want to uninstall.
+    Specifies the software type to uninstall. 
+    Set it to '1' for .msi-based software, '0' for .exe-based software, or omit to target both types based on other criteria.
 
     Specifying a value of 0 will look for software where WindowsInstaller is equal to 0, or not present at all.
 .PARAMETER SystemComponent

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/readme.md
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/readme.md
@@ -167,16 +167,8 @@ Accept wildcard characters: False
 ```
 
 ### -WindowsInstaller
-Specify a value between 1 and 0 to use as an additional criteria when trying to find installed software.
 
-If WindowsInstaller registry value has a data of 1, it generally means software was installed from MSI.
-Omitting the parameter entirely or specify a value of 0 generally means software was installed from EXE
-
-This is useful to be more specific about software titles you want to uninstall.
-
-Specifying a value of 0 will look for software where WindowsInstaller is equal to 0, or not present at all.
-
-If this parameter is not specified at all, the script will try to uninstall both EXE and MSI instances of the software.
+Specifies the software type to uninstall. Set it to ```1``` for .msi-based software, ```0``` for .exe-based software, or omit to target both types based on other criteria.
 
 ```yaml
 Type: Int32

--- a/Uninstall/Pre-Uninstall/Uninstall-Software/readme.md
+++ b/Uninstall/Pre-Uninstall/Uninstall-Software/readme.md
@@ -170,12 +170,13 @@ Accept wildcard characters: False
 Specify a value between 1 and 0 to use as an additional criteria when trying to find installed software.
 
 If WindowsInstaller registry value has a data of 1, it generally means software was installed from MSI.
-
 Omitting the parameter entirely or specify a value of 0 generally means software was installed from EXE
 
 This is useful to be more specific about software titles you want to uninstall.
 
 Specifying a value of 0 will look for software where WindowsInstaller is equal to 0, or not present at all.
+
+If this parameter is not specified at all, the script will try to uninstall both EXE and MSI instances of the software.
 
 ```yaml
 Type: Int32


### PR DESCRIPTION
Improved the ReadMe.md and comment for the ```-WindowsInstaller``` param.

The previous documentation did not specify that, if the param is omitted, the script will uninstall both EXE and MSI file