### PR TITLE
Update PatchMyPC-CustomAppsHelper.ps1

### DIFF
--- a/Other/CustomAppsHelper/PatchMyPC-CustomAppsHelper.ps1
+++ b/Other/CustomAppsHelper/PatchMyPC-CustomAppsHelper.ps1
@@ -23,8 +23,7 @@ $Apps = (Get-ChildItem HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall
 $SelectedApp = $Apps | Sort-Object WindowsInstaller, DisplayName, SystemComponent | Out-GridView -Title "Select Application" -OutputMode Single | Select-Object -First 1
 
 if ($SelectedApp) {
-	$SelectedApp.DisplayName -match '(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.\d+)' | Out-Null
-	if ($Matches) {
+	if ($SelectedApp.DisplayName -match '(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.\d+)' | Out-Null) {
 		$version = $Matches[0]
 		$DisplayNameNew = ($SelectedApp.DisplayName).Replace($version, '%')
 	}


### PR DESCRIPTION
make it compatible with PS 5.1 where if no match is found, $matches[0] will contain an empty string (''), and $matches will still be populated with keys (like 0 for the whole match and additional group captures, even if they're empty).

## Pull Request Type

- [ ] New Script
- [x] Edit Script
- [ ] Repository Improvement

## Brief summary of changes

Describe what you changed or added, and why you think it would be helpful to the community.

## Describe your Testing

Describe the scenario this script would be used for, and how you tested it. 

## Checklist

- [ ] Did you Clean your script - No environment details, comments are PG-13
- [ ] Did you test your script
- [ ] If required, did you create, and include a Read Me as outlined in [Community Scripts Read Me](README.MD)

## Notes for PMPC Team

Include any other generic notes for the PMPC review team here.
