### PR TITLE
Added instructions and script to support deployment of an additional code-signing certificate

### DIFF
--- a/Other/Code Signing/Import-PMPCAppsTrustedPublisherCertificate.ps1
+++ b/Other/Code Signing/Import-PMPCAppsTrustedPublisherCertificate.ps1
@@ -1,0 +1,107 @@
+<#
+.SYNOPSIS
+    Imports the Patch My PC code-signing certificate public key into the local machine Trusted Publishers store.
+    This certificate is used to sign required and recommended pre/post scripts for certain applications in the Patch My PC catalog.
+
+.NOTES
+    FileName:    Import-PMPCAppsTrustedPublisherCertificate.ps1
+    Author:      Ben Whitmore
+    Date:        20th June 2025
+    
+.DESCRIPTION
+    This script imports the Patch My PC code-signing certificate public key into the local machine Trusted Publishers store. 
+    The certificate is store in base64 format in the script and is converted to a certificate object before being added to the store.
+
+    NOTE: This script requires elevated permissions to install the certificate into the Local Machine store.
+
+    # The following code was used to import the certificate as a Base64-encoded string
+    $certPath = 'C:\Temp\PmpcScripts\certs\Patch My PC LLC.cer'
+    $bytes = [System.IO.File]::ReadAllBytes($certPath)
+    $base64 = [System.Convert]::ToBase64String($bytes)
+#>
+
+# Base64-encoded certificate content
+$base64Cert = @"
+MIIHyTCCBbGgAwIBAgIQDMNw87U7UZ48Hv1za61jojANBgkqhkiG9w0BAQsFADBpMQswCQYDVQQG
+EwJVUzEXMBUGA1UEChMORGlnaUNlcnQsIEluYy4xQTA/BgNVBAMTOERpZ2lDZXJ0IFRydXN0ZWQg
+RzQgQ29kZSBTaWduaW5nIFJTQTQwOTYgU0hBMzg0IDIwMjEgQ0ExMB4XDTIzMDQwNzAwMDAwMFoX
+DTI2MDQzMDIzNTk1OVowgdExEzARBgsrBgEEAYI3PAIBAxMCVVMxGTAXBgsrBgEEAYI3PAIBAhMI
+Q29sb3JhZG8xHTAbBgNVBA8MFFByaXZhdGUgT3JnYW5pemF0aW9uMRQwEgYDVQQFEwsyMDEzMTYz
+ODMyNzELMAkGA1UEBhMCVVMxETAPBgNVBAgTCENvbG9yYWRvMRQwEgYDVQQHEwtDYXN0bGUgUm9j
+azEZMBcGA1UEChMQUGF0Y2ggTXkgUEMsIExMQzEZMBcGA1UEAxMQUGF0Y2ggTXkgUEMsIExMQzCC
+AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKaQcs40YzBFv5HXQFPd04rKJ4uBdwvAZLKu
+ULy+icZOpgs/Sy329Ng5ikhB5o1IdvE2cOT20sjs3qgb4e+rqs7taTCe6RNLsDINsmcTlp4yxOfV
+80EZ08ld3o36GEgH0Vy1vrJXLTRKNULzV7gIzF/e3tO1Fab4IxKZNcBSXiv8ORqcgT9O7/RZoqyG
+87iU6Q/dKfC4WzvU396XJ3FMZrI+s4CgV8p6pVNjijBjH7pmzoXynFtA0j6NH6tg4DmQvm+kfWXt
+WbDpPYhdFz1gccJt1DjTrJetpIwBzDAS8NGA75HQhBmQ3gcnNDJLgylB3HyWOeXS+vxXR0Pi/W41
+9cfn8zCFH0u2O4QFaZsT2HoIE/t9EhdAKdHoKwvVoCgwvlx3jjwFq5MnoB2oJiNmTGQyhiRvCaw6
+JACKUa43eJvlRKylEy4INDTOX5BeivJoTqCw0cCAd6ZuRh6gRl8shIVfN78qunQqJZQkDimtQY5S
+n33w+ee5/lFSxOxBg6iu7vCGPZ6QxJd6oVdRa8t87vJ4QVlsMQQRa400S7kqIX1HOnbR3hxgvcks
+8kBRMYtZ8g3Fz/WTCW5sWbExVpn6HC6DsRhosF/DBGYmIqQJz6odkCFCr7QcmpGjoZs4jRDegSC5
+utEusBYmvCfVxtud3R43WEdCRfHuD1OFDm5HoonnAgMBAAGjggICMIIB/jAfBgNVHSMEGDAWgBRo
+N+Drtjv4XxGG+/5hewiIZfROQjAdBgNVHQ4EFgQU3wgET0b7maQo7OF3wwGWm83hl+0wDgYDVR0P
+AQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMDMIG1BgNVHR8Ega0wgaowU6BRoE+GTWh0dHA6
+Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydFRydXN0ZWRHNENvZGVTaWduaW5nUlNBNDA5NlNI
+QTM4NDIwMjFDQTEuY3JsMFOgUaBPhk1odHRwOi8vY3JsNC5kaWdpY2VydC5jb20vRGlnaUNlcnRU
+cnVzdGVkRzRDb2RlU2lnbmluZ1JTQTQwOTZTSEEzODQyMDIxQ0ExLmNybDA9BgNVHSAENjA0MDI
+GBWeBDAEDMCkwJwYIKwYBBQUHAgEWG2h0dHA6Ly93d3cuZGlnaWNlcnQuY29tL0NQUzCBlAYIKwYB
+BQUHAQEEgYcwgYQwJAYIKwYBBQUHMAGGGGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0LmNvbTBcBggrBgEF
+BQcwAoZQaHR0cDovL2NhY2VydHMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0VHJ1c3RlZEc0Q29kZVNp
+Z25pbmdSU0E0MDk2U0hBMzg0MjAyMUNBMS5jcnQwCQYDVR0TBAIwADANBgkqhkiG9w0BAQsFAAOC
+AgEADaIfBgYBzz7rZspAw5OGKL7nt4eo6SMcS91NAex1HWxak4hX7yqQB25Oa66WaVBtd14rZxpt
+oGQ88FDezI1qyUs4bwi4NaW9WBY8QDnGGhgyZ3aT3ZEBEvMWy6MFpzlyvjPBcWE5OGuoRMhP42TS
+MhvFlZGCPZy02PLUdGcTynL55YhdTcGJnX0Z2OgSaHUQTmXhgRX+fajIilPnmmv8Av4Clr6Xa9So
+NHltA04JRiCu4ejDGFqA94F696jSJ+AUYHys6bnPc0E8JB9YnFCAurPRG8YBJAofUtxnGIHGE0Ei
+QTZeXf0nKmVBIXkE3hT4mZx7pH7wrlCr0FV4qnq6j0uaj4oKqFbkdyzb5u+XQe9pPojshnjVzhIR
+K53wsGaFP4gSURxWvcThIOyoaKrVDZOdLQZXEz8Anks3Vs5XscjyzFR7pv/3Reik7FaZRTvd5rDW
+6foDJOiCwX5p+UnldHGHW83rDvtks1rwgKwuuxvCG3Bkjirl94EImpiugGaRQ7S2Lydxpqzv7Hng
+4YQbIIvVMNC7mNrVZPNWdF4/a9yjDt2nJrnRcDK1zvHBXSrAYIycQ6hhhlHS9Y4MRhz35t1du/Y0
+IXDB7HBYSvcsrpxtBzXLTd2NCNCtdkwYIl7WTQeoCbZWvo4PbzJBOnPjs1tN4upe9XomxtZkNAwI
+OfM=
+"@
+
+try {
+
+    # Convert the Base64 string to byte array
+    $certBytes = [System.Convert]::FromBase64String($base64Cert)
+    $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($certBytes)
+
+    # Open the Trusted Publisher store with ReadWrite permissions
+    $store = [System.Security.Cryptography.X509Certificates.X509Store]::new("TrustedPublisher", "LocalMachine")
+    $store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+
+    try {
+
+        # Check if the certificate already exists in the store
+        $certExists = $store.Certificates | Where-Object { $_.Thumbprint -eq $cert.Thumbprint }
+
+        if ($certExists) {
+            Write-Output "Patch My PC Apps certificate already exists in the Local Machine Trusted Publisher store"
+        }
+        else {
+            # Add the certificate to the store
+            $store.Add($cert)
+            Write-Output "Patch My PC Apps certificate successfully imported into the Local Machine Trusted Publisher store"
+        }
+    }
+    catch {
+
+        throw "An error occurred importing the certificate: $_"
+    }
+    finally {
+
+        # Close the store
+        $store.Close()
+    }
+}
+catch {
+    throw "An error setting up the certificate or opening the store: $_"
+}
+finally {
+
+    # Clear the Base64 certificate content
+    $base64Cert = $null
+    $certBytes = $null
+    $cert = $null
+    $store = $null
+}

--- a/Other/Code Signing/Import-PMPCCloudTrustedPublisherCertificate.ps1
+++ b/Other/Code Signing/Import-PMPCCloudTrustedPublisherCertificate.ps1
@@ -1,12 +1,14 @@
 <#
 .SYNOPSIS
     Imports the Patch My PC code-signing certificate public key into the local machine Trusted Publishers store.
+    This certificate is used to sign detection and remediation scripts for Patch My PC applications published using Patch My PC Cloud.
 
 .NOTES
-    FileName:    Import-PMPTrustedPublisherCertificate.ps1
+    FileName:    Import-PMPCCloudTrustedPublisherCertificate.ps1
     Author:      Ben Whitmore
     Date:        25th June 2024
-    
+    Updated:     20th June 2025
+
 .DESCRIPTION
     This script imports the Patch My PC code-signing certificate public key into the local machine Trusted Publishers store. 
     The certificate is store in base64 format in the script and is converted to a certificate object before being added to the store.
@@ -14,8 +16,9 @@
     NOTE: This script requires elevated permissions to install the certificate into the Local Machine store.
 
     # The following code was used to import the certificate as a Base64-encoded string
-    $certPath = "C:\Path\PatchMyPC-CodeSigning.cer"
-    $base64Cert = [System.Convert]::ToBase64String(([System.Security.Cryptography.X509Certificates.X509Certificate2]::new($certPath))
+    $certPath = 'C:\Temp\PmpcScripts\certs\Patch My PC LLC.cer'
+    $bytes = [System.IO.File]::ReadAllBytes($certPath)
+    $base64 = [System.Convert]::ToBase64String($bytes)
 #>
 
 # Base64-encoded certificate content
@@ -71,12 +74,12 @@ try {
         $certExists = $store.Certificates | Where-Object { $_.Thumbprint -eq $cert.Thumbprint }
 
         if ($certExists) {
-            Write-Output "Patch My PC certificate already exists in the Local Machine Trusted Publisher store"
+            Write-Output "Patch My PC Cloud certificate already exists in the Local Machine Trusted Publisher store"
         }
         else {
             # Add the certificate to the store
             $store.Add($cert)
-            Write-Output "Patch My PC certificate successfully imported into the Local Machine Trusted Publisher store"
+            Write-Output "Patch My PC Cloud certificate successfully imported into the Local Machine Trusted Publisher store"
         }
     }
     catch {

--- a/Other/Code Signing/PMPCAppsTrustedPublisherCertificate_HealthScript_Detection.ps1
+++ b/Other/Code Signing/PMPCAppsTrustedPublisherCertificate_HealthScript_Detection.ps1
@@ -1,0 +1,102 @@
+<#
+.SYNOPSIS
+    Proactive Remediation (Health Script) to test if the Patch My PC code-signing certificate is installed in the Local Machine Trusted Publisher store.
+    This certificate is used to sign required and recommended pre/post scripts for certain applications in the Patch My PC catalog.
+
+.NOTES
+    FileName:    PMPCAppsTrustedPublisherCertificate_HealthScript_Detection.ps1
+    Author:      Ben Whitmore
+    Date:        20th June 2025
+    
+.DESCRIPTION
+    This script checks if the Patch My PC code-signing certificate is installed in the Local Machine Trusted Publisher store. 
+    The certificate is store in base64 format in the script and is converted to a certificate object before being added to the store.
+
+    # The following code was used to import the certificate as a Base64-encoded string
+    $certPath = 'C:\Temp\PmpcScripts\certs\Patch My PC LLC.cer'
+    $bytes = [System.IO.File]::ReadAllBytes($certPath)
+    $base64 = [System.Convert]::ToBase64String($bytes)
+#>
+
+# Base64-encoded certificate content
+$base64Cert = @"
+MIIHyTCCBbGgAwIBAgIQDMNw87U7UZ48Hv1za61jojANBgkqhkiG9w0BAQsFADBpMQswCQYDVQQG
+EwJVUzEXMBUGA1UEChMORGlnaUNlcnQsIEluYy4xQTA/BgNVBAMTOERpZ2lDZXJ0IFRydXN0ZWQg
+RzQgQ29kZSBTaWduaW5nIFJTQTQwOTYgU0hBMzg0IDIwMjEgQ0ExMB4XDTIzMDQwNzAwMDAwMFoX
+DTI2MDQzMDIzNTk1OVowgdExEzARBgsrBgEEAYI3PAIBAxMCVVMxGTAXBgsrBgEEAYI3PAIBAhMI
+Q29sb3JhZG8xHTAbBgNVBA8MFFByaXZhdGUgT3JnYW5pemF0aW9uMRQwEgYDVQQFEwsyMDEzMTYz
+ODMyNzELMAkGA1UEBhMCVVMxETAPBgNVBAgTCENvbG9yYWRvMRQwEgYDVQQHEwtDYXN0bGUgUm9j
+azEZMBcGA1UEChMQUGF0Y2ggTXkgUEMsIExMQzEZMBcGA1UEAxMQUGF0Y2ggTXkgUEMsIExMQzCC
+AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKaQcs40YzBFv5HXQFPd04rKJ4uBdwvAZLKu
+ULy+icZOpgs/Sy329Ng5ikhB5o1IdvE2cOT20sjs3qgb4e+rqs7taTCe6RNLsDINsmcTlp4yxOfV
+80EZ08ld3o36GEgH0Vy1vrJXLTRKNULzV7gIzF/e3tO1Fab4IxKZNcBSXiv8ORqcgT9O7/RZoqyG
+87iU6Q/dKfC4WzvU396XJ3FMZrI+s4CgV8p6pVNjijBjH7pmzoXynFtA0j6NH6tg4DmQvm+kfWXt
+WbDpPYhdFz1gccJt1DjTrJetpIwBzDAS8NGA75HQhBmQ3gcnNDJLgylB3HyWOeXS+vxXR0Pi/W41
+9cfn8zCFH0u2O4QFaZsT2HoIE/t9EhdAKdHoKwvVoCgwvlx3jjwFq5MnoB2oJiNmTGQyhiRvCaw6
+JACKUa43eJvlRKylEy4INDTOX5BeivJoTqCw0cCAd6ZuRh6gRl8shIVfN78qunQqJZQkDimtQY5S
+n33w+ee5/lFSxOxBg6iu7vCGPZ6QxJd6oVdRa8t87vJ4QVlsMQQRa400S7kqIX1HOnbR3hxgvcks
+8kBRMYtZ8g3Fz/WTCW5sWbExVpn6HC6DsRhosF/DBGYmIqQJz6odkCFCr7QcmpGjoZs4jRDegSC5
+utEusBYmvCfVxtud3R43WEdCRfHuD1OFDm5HoonnAgMBAAGjggICMIIB/jAfBgNVHSMEGDAWgBRo
+N+Drtjv4XxGG+/5hewiIZfROQjAdBgNVHQ4EFgQU3wgET0b7maQo7OF3wwGWm83hl+0wDgYDVR0P
+AQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMDMIG1BgNVHR8Ega0wgaowU6BRoE+GTWh0dHA6
+Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydFRydXN0ZWRHNENvZGVTaWduaW5nUlNBNDA5NlNI
+QTM4NDIwMjFDQTEuY3JsMFOgUaBPhk1odHRwOi8vY3JsNC5kaWdpY2VydC5jb20vRGlnaUNlcnRU
+cnVzdGVkRzRDb2RlU2lnbmluZ1JTQTQwOTZTSEEzODQyMDIxQ0ExLmNybDA9BgNVHSAENjA0MDI
+GBWeBDAEDMCkwJwYIKwYBBQUHAgEWG2h0dHA6Ly93d3cuZGlnaWNlcnQuY29tL0NQUzCBlAYIKwYB
+BQUHAQEEgYcwgYQwJAYIKwYBBQUHMAGGGGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0LmNvbTBcBggrBgEF
+BQcwAoZQaHR0cDovL2NhY2VydHMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0VHJ1c3RlZEc0Q29kZVNp
+Z25pbmdSU0E0MDk2U0hBMzg0MjAyMUNBMS5jcnQwCQYDVR0TBAIwADANBgkqhkiG9w0BAQsFAAOC
+AgEADaIfBgYBzz7rZspAw5OGKL7nt4eo6SMcS91NAex1HWxak4hX7yqQB25Oa66WaVBtd14rZxpt
+oGQ88FDezI1qyUs4bwi4NaW9WBY8QDnGGhgyZ3aT3ZEBEvMWy6MFpzlyvjPBcWE5OGuoRMhP42TS
+MhvFlZGCPZy02PLUdGcTynL55YhdTcGJnX0Z2OgSaHUQTmXhgRX+fajIilPnmmv8Av4Clr6Xa9So
+NHltA04JRiCu4ejDGFqA94F696jSJ+AUYHys6bnPc0E8JB9YnFCAurPRG8YBJAofUtxnGIHGE0Ei
+QTZeXf0nKmVBIXkE3hT4mZx7pH7wrlCr0FV4qnq6j0uaj4oKqFbkdyzb5u+XQe9pPojshnjVzhIR
+K53wsGaFP4gSURxWvcThIOyoaKrVDZOdLQZXEz8Anks3Vs5XscjyzFR7pv/3Reik7FaZRTvd5rDW
+6foDJOiCwX5p+UnldHGHW83rDvtks1rwgKwuuxvCG3Bkjirl94EImpiugGaRQ7S2Lydxpqzv7Hng
+4YQbIIvVMNC7mNrVZPNWdF4/a9yjDt2nJrnRcDK1zvHBXSrAYIycQ6hhhlHS9Y4MRhz35t1du/Y0
+IXDB7HBYSvcsrpxtBzXLTd2NCNCtdkwYIl7WTQeoCbZWvo4PbzJBOnPjs1tN4upe9XomxtZkNAwI
+OfM=
+"@
+
+try {
+
+    # Convert the Base64 string to byte array
+    $certBytes = [System.Convert]::FromBase64String($base64Cert)
+    $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($certBytes)
+
+    # Open the Trusted Publisher store with ReadWrite permissions
+    $store = [System.Security.Cryptography.X509Certificates.X509Store]::new("TrustedPublisher", "LocalMachine")
+    $store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+
+    try {
+
+        # Check if the certificate already exists in the store
+        $certExists = $store.Certificates | Where-Object { $_.Thumbprint -eq $cert.Thumbprint }
+
+        if ($certExists) {
+            Write-Output "Certificate Installed"
+            exit 0
+        } else {
+            exit 1
+        }
+    }
+    catch {
+        throw "An error occurred importing the certificate: $_"
+    }
+    finally {
+
+        # Close the store
+        $store.Close()
+    }
+}
+catch {
+    throw "An error setting up the certificate or opening the store: $_"
+}
+finally {
+
+    # Clear the Base64 certificate content
+    $base64Cert = $null
+    $certBytes = $null
+    $cert = $null
+    $store = $null
+}

--- a/Other/Code Signing/PMPCCloudTrustedPublisherCertificate_HealthScript_Detection.ps1
+++ b/Other/Code Signing/PMPCCloudTrustedPublisherCertificate_HealthScript_Detection.ps1
@@ -1,19 +1,22 @@
 <#
 .SYNOPSIS
     Proactive Remediation (Health Script) to test if the Patch My PC code-signing certificate is installed in the Local Machine Trusted Publisher store.
+    This certificate is used to sign detection and remediation scripts for Patch My PC applications published using Patch My PC Cloud.
 
 .NOTES
-    FileName:    PMPTrustedPublisherCertificate_HealthScript_Detection.ps1
+    FileName:    PMPCCloudTrustedPublisherCertificate_HealthScript_Detection.ps1
     Author:      Ben Whitmore
     Date:        25th June 2024
+    Updated:     20th June 2025
     
 .DESCRIPTION
     This script checks if the Patch My PC code-signing certificate is installed in the Local Machine Trusted Publisher store. 
     The certificate is store in base64 format in the script and is converted to a certificate object before being added to the store.
 
     # The following code was used to import the certificate as a Base64-encoded string
-    $certPath = "C:\Path\PatchMyPC-CodeSigning.cer"
-    $base64Cert = [System.Convert]::ToBase64String(([System.Security.Cryptography.X509Certificates.X509Certificate2]::new($certPath))
+    $certPath = 'C:\Temp\PmpcScripts\certs\Patch My PC LLC.cer'
+    $bytes = [System.IO.File]::ReadAllBytes($certPath)
+    $base64 = [System.Convert]::ToBase64String($bytes)
 #>
 
 # Base64-encoded certificate content

--- a/Other/Code Signing/ReadMe.md
+++ b/Other/Code Signing/ReadMe.md
@@ -1,52 +1,83 @@
-# Patch My PC Trusted Publisher Certificate Import Script
+# Patch My PC Trusted Publisher Certificate Import Scripts
 
-## Intune Platform Script or other method
-This PowerShell script imports a Base64-encoded certificate into the Local Machine Trusted Publisher store. It checks if the certificate already exists in the store before attempting to add it.
-The certificate is required in the Trusted Publisher certificate store if you are enforcing an AllSigned PowerShell execution policy.
+## Overview
 
-### Script Overview
+These PowerShell scripts import Base64-encoded certificates into the Local Machine Trusted Publisher store. The certificates are required in the Trusted Publisher certificate store if you are enforcing an AllSigned PowerShell execution policy. These scripts are designed to work with Patch My PC Cloud and Patch My PC catalog applications, ensuring that detection, requirement, and pre/post deployment scripts can run without issues in environments with strict PowerShell execution policies.
 
-The script performs the following steps:
+## Available Scripts
 
-1. Converts a Base64-encoded certificate string to a byte array.
-2. Creates an X509Certificate2 object from the byte array.
-3. Opens the Trusted Publisher store on the Local Machine with ReadWrite permissions.
-4. Checks if the certificate already exists in the store.
-5. If the certificate does not exist, it adds the certificate to the store.
-6. Handles any errors that occur during the process and provides appropriate output messages.
+There are two scripts available:
 
-### Usage
+> ⚠️**IMPORTANT**  
+> If you're using Patch My PC Cloud and have an `AllSigned` PowerShell execution policy in place, you may need to deploy **both certificates**. One is required for **detection/requirement scripts**, and the other for **pre/post deployment scripts** used with some applications in the Patch My PC catalog.
+  
+- **`Import-PMPCCloudTrustedPublisherCertificate.ps1`**  
+  Installs the certificate used to sign **Intune detection and requirement scripts** for Win32 applications published through Patch My PC Cloud.  
+  This certificate ensures that app detection and requirement logic can run in environments enforcing an `AllSigned` PowerShell execution policy.
 
-1. Save the script to a `.ps1` file, for example, `Import-PMPTrustedPublisherCertificate.ps1`.
-2. Run the script using PowerShell. This script can be deployed as a platform script or a proactive remediation in Intune.
+- **`Import-PMPCAppsTrustedPublisherCertificate.ps1`**  
+  Installs the certificate used to sign **required and recommended pre/post scripts** for certain applications in the Patch My PC catalog.  
+  These scripts perform tasks like stopping processes, uninstalling older versions, or configuring app behavior during deployment.
+  This certificate ensures that PMPC defined pre/post scripts can run in environments enforcing an `AllSigned` PowerShell execution policy.
 
-#### Running the Script
+## How the Scripts Work
+
+Both scripts perform the following steps:
+
+1. Convert a Base64-encoded certificate string to a byte array
+2. Create an X509Certificate2 object from the byte array
+3. Open the Trusted Publisher store on the Local Machine with ReadWrite permissions
+4. Check if the certificate already exists in the store
+5. If the certificate does not exist, add the certificate to the store
+6. Handle any errors that occur during the process and provide appropriate output messages
+
+## Deployment Methods
+
+### Method 1: Intune Platform Script or Manual Execution
+
+You can deploy these scripts as Intune platform scripts or run them manually via PowerShell.
+
+#### Usage
+1. Save the desired script to a `.ps1` file
+2. Deploy as a platform script in Intune, or run manually using PowerShell:
 
 ```powershell
-.\Import-PMPTrustedPublisherCertificate.ps1
+.\Import-PMPCCloudTrustedPublisherCertificate.ps1
+.\Import-PMPCAppsTrustedPublisherCertificate.ps1
 ```
 
-## Proactive Remediation
-PMPTrustedPublisherCertificate_HealthScript_Detection.ps1 can be used as a detection script file for a proactive remediation
-Import-PMPTrustedPublisherCertificate.ps1 can be used as the remediation script
-The certificate is required in the Trusted Publisher certificate store if you are enforcing an AllSigned PowerShell execution policy.
+### Method 2: Proactive Remediation
 
-### Script Overview
+#### For the Patch My PC Cloud Certificate
+- **Detection Script**: `PMPCCloudTrustedPublisherCertificate_HealthScript_Detection.ps1`
+- **Remediation Script**: `Import-PMPCCloudTrustedPublisherCertificate.ps1`
 
-The detection script (PMPTrustedPublisherCertificate_HealthScript_Detection.ps1) performs the following steps:
+#### For the Patch My PC Apps Certificate
+- **Detection Script**: `PMPCAppsTrustedPublisherCertificate_HealthScript_Detection.ps1`
+- **Remediation Script**: `Import-PMPCAppsTrustedPublisherCertificate.ps1`
 
-1. Converts a Base64-encoded certificate string to a byte array.
-2. Creates an X509Certificate2 object from the byte array.
-3. Opens the Trusted Publisher store on the Local Machine with ReadWrite permissions.
-4. Checks if the certificate already exists in the store.
+#### Script Overview
+
+The detection scripts (`PMPCCloudTrustedPublisherCertificate_HealthScript_Detection.ps1` and `PMPCAppsTrustedPublisherCertificate_HealthScript_Detection.ps1`) perform the following steps:
+
+1. Converts a Base64-encoded certificate string to a byte array
+2. Creates an X509Certificate2 object from the byte array
+3. Opens the Trusted Publisher store on the Local Machine with ReadWrite permissions
+4. Checks if the certificate already exists in the store
 5. If the certificate does not exist, it exits the script with exit code 1 (indicating remediation is required)
 6. If the certificate is already installed, it exits the script with a STD output stream and exit code 0 (indicating remediation is not required)
 
-The remediation script (Import-PMPTrustedPublisherCertificate.ps1) performs the following steps:
+The remediation scripts (`Import-PMPCCloudTrustedPublisherCertificate.ps1` and `Import-PMPCAppsTrustedPublisherCertificate.ps1`) perform the following steps:
 
-1. Converts a Base64-encoded certificate string to a byte array.
-2. Creates an X509Certificate2 object from the byte array.
-3. Opens the Trusted Publisher store on the Local Machine with ReadWrite permissions.
-4. Checks if the certificate already exists in the store.
-5. If the certificate does not exist, it adds the certificate to the store.
-6. Handles any errors that occur during the process and provides appropriate output messages.
+1. Converts a Base64-encoded certificate string to a byte array
+2. Creates an X509Certificate2 object from the byte array
+3. Opens the Trusted Publisher store on the Local Machine with ReadWrite permissions
+4. Checks if the certificate already exists in the store
+5. If the certificate does not exist, it adds the certificate to the store
+6. Handles any errors that occur during the process and provides appropriate output messages
+
+## Requirements
+
+- PowerShell execution policy that allows script execution
+- Administrative privileges to modify the Local Machine certificate store
+- Windows PowerShell 5.1 or later


### PR DESCRIPTION
We now have scripts for both the PMPCApps and PMPCCloud trusted publisher code-signing certificates. PMPCCloud certificate is used to sign detection and remediation scripts for the PMPC Cloud service. PMPCApps certificate is used to sign pre/post scripts for certain apps in the PMPC catalog.

## Pull Request Type

- [x] New Script
- [x] Edit Script
- [ ] Repository Improvement

## Brief summary of changes

Updated the repository to include additional scripts to support the updated docs. FOr customers who have an AllSigned PowerShell policy, they must also deploy the public key of the certificate we use to sign our helper scripts, like uninstall-software.ps1

## Describe your Testing

Proactive Remediations and/or Platform script from Intune to install the Public key portion of the certificate to the Trusted Publishers store on a client device.

## Checklist

- [x] Did you Clean your script - No environment details, comments are PG-13
- [x] Did you test your script
- [x] If required, did you create, and include a Read Me as outlined in [Community Scripts Read Me](README.MD)

## Notes for PMPC Team

Include any other generic notes for the PMPC review team here.
