### PR TITLE
Add params to New-Shortcut: Arguments, ExpandEnvironmentVariables, As32on64

### DIFF
--- a/Install/Post-Install/New-Shortcut/New-Shortcut.ps1
+++ b/Install/Post-Install/New-Shortcut/New-Shortcut.ps1
@@ -39,10 +39,10 @@
     Indicates that the shortcut should be created under the user StartMenu or Desktop rather than allusers StartMenu or public Desktop.
 
 .PARAMETER ExpandEnvironmentVariables
-    Indicates that environment variables in the shortcut Target, WorkingDirectory, and IconPath should be expanded.
+    Expand environment variables in the shortcut Target, Arguments, WorkingDirectory, and IconPath.
 
 .PARAMETER As32on64
-    When expanding environment variables on a 64-bit system, treat %ProgramFiles% as %ProgramFiles(x86)% and %CommonProgramFiles% as %CommonProgramFiles(x86)%. Use this in conjunction with -ExpandEnvironmentVariables when %ProgramFiles% should be interpreted as C:\Program Files (x86) on a 64-bit OS.
+    Expand %ProgramFiles% and %CommonProgramFiles% as if they were 32-bit on 64-bit systems. Use this in conjunction with -ExpandEnvironmentVariables when %ProgramFiles% should be interpreted as C:\Program Files (x86) on a 64-bit OS.
 
 .PARAMETER Shortcuts
     An array of hashtable entries for creating multiple shortcuts. Each hashtable should include the parameters as keys.
@@ -56,6 +56,16 @@
     .\New-Shortcut.ps1 -Shortcuts @(@{Name="Example1"; Target="C:\Path\To\Target.exe"; Desktop=$true;},@{Name="Example2"; Target="C:\Path\To\Target.exe"; StartMenu=$true; Path="SubFolder"})
 
     This creates two shortcuts, one named "Example1" on the desktop and another named "Example2" in the Start Menu folder named "SubFolder".
+
+.EXAMPLE
+    .\New-Shortcut.ps1 -Path 'MyApp' -Name 'MyApp' -Target "%ProgramFiles%\MyApp\MyApp.exe" -Arguments '/Something' -IconPath "%ProgramFiles%\MyApp\MyApp.exe" -StartMenu -ExpandEnvironmentVariables
+
+    This creates a shortcut named "MyApp" in a Start Menu folder named "MyApp", pointing to the target executable in Program Files, with specified arguments and icon.
+
+.EXAMPLE
+    .\New-Shortcut.ps1 -Path 'MyApp' -Name 'MyApp' -Target "%ProgramFiles%\MyApp\MyApp.exe" -Arguments '/Something' -IconPath "%ProgramFiles%\MyApp\MyApp.exe" -StartMenu -ExpandEnvironmentVariables -As32on64
+
+    This creates a shortcut named "MyApp" in a Start Menu folder named "MyApp", pointing to the target executable in Program Files on a 32-bit OS / Program Files (x86) on a 64-bit OS.
 
 .INPUTS
     You can pipe an array of hashtable entries to New-Shortcut.ps1.

--- a/Install/Post-Install/New-Shortcut/README.md
+++ b/Install/Post-Install/New-Shortcut/README.md
@@ -8,6 +8,7 @@
 - **Path**: Specifies the path where the shortcut should be created. Mandatory for custom locations. For Desktop or StartMenu shortcuts, this parameter defines the subfolder name.
 - **Name**: The name of the shortcut. This is a mandatory parameter.
 - **Target**: The target path of the shortcut. This is a mandatory parameter.
+- **Arguments**: The arguments to pass to the target application.
 - **WorkingDirectory**: The working directory for the shortcut.
 - **IconPath**: The path to the icon file for the shortcut.
 - **IconIndex**: The index of the icon within the icon file. Will default to 0.
@@ -15,6 +16,8 @@
 - **StartMenu**: Indicates that the shortcut should be created in the Start Menu.
 - **Desktop**: Indicates that the shortcut should be created on the Desktop. This is mutually exclusive with -StartMenu.
 - **User**: Specifies that the shortcut should be created under the user's StartMenu or Desktop rather than for all users.
+- **ExpandEnvironmentVariables**: Expand environment variables in the shortcut Target, Arguments, WorkingDirectory, and IconPath.
+- **As32on64**: Expand %ProgramFiles% and %CommonProgramFiles% as if they were 32-bit on 64-bit systems. Use this in conjunction with -ExpandEnvironmentVariables when %ProgramFiles% should be interpreted as C:\Program Files (x86) on a 64-bit OS.
 - **Shortcuts**: An array of hashtable entries for creating multiple shortcuts. Each hashtable should include the parameters as keys.
 
 ## Examples
@@ -27,4 +30,14 @@
 ### Example 2: Creating Multiple Shortcuts
 ```powershell
 .\New-Shortcut.ps1 -Shortcuts @(@{Name="Example1"; Target="C:\Path\To\Target.exe"; Desktop=$true;}, @{Name="Example2"; Target="C:\Path\To\Target.exe"; StartMenu=$true; Path="SubFolder"})
+```
+
+### Example 3: Creating a Shortcut in Program Files
+```powershell
+.\New-Shortcut.ps1 -Path 'MyApp' -Name 'MyApp' -Target "%ProgramFiles%\MyApp\MyApp.exe" -Arguments '/Something' -IconPath "%ProgramFiles%\MyApp\MyApp.exe" -StartMenu -ExpandEnvironmentVariables
+```
+
+### Example 4: Creating a Shortcut in Program Files on a 32-bit OS and Program Files (x86) on a 64-bit OS
+```powershell
+.\New-Shortcut.ps1 -Path 'MyApp' -Name 'MyApp' -Target "%ProgramFiles%\MyApp\MyApp.exe" -Arguments '/Something' -IconPath "%ProgramFiles%\MyApp\MyApp.exe" -StartMenu -ExpandEnvironmentVariables -As32on64
 ```


### PR DESCRIPTION
## Pull Request Type

- [ ] New Script
- [x] Edit Script
- [ ] Repository Improvement

## Brief summary of changes

.PARAMETER Arguments
    The arguments to pass to the target application.

.PARAMETER ExpandEnvironmentVariables
    Indicates that environment variables in the shortcut Target, WorkingDirectory, and IconPath should be expanded.

.PARAMETER As32on64
    When expanding environment variables on a 64-bit system, treat %ProgramFiles% as %ProgramFiles(x86)% and %CommonProgramFiles% as %CommonProgramFiles(x86)%. Use this in conjunction with -ExpandEnvironmentVariables when %ProgramFiles% should be interpreted as C:\Program Files (x86) on a 64-bit OS.

## Describe your Testing

```
.\New-Shortcut.ps1 -Path 'Test' -StartMenu -User -Name 'Test' -Target "%ProgramFiles%\Docker\Docker\Docker Desktop.exe" -Arguments '/s' -IconPath "%ProgramFiles%\Docker\Docker\Docker Desktop.exe" -ExpandEnvironmentVariables

.\New-Shortcut.ps1 -Path 'Test' -StartMenu -User -Name 'Test' -Target "%ProgramFiles%\Master Packager Ltd\Master Packager\MasterPackager.exe" -Arguments '/s'  -WorkingDirectory "%ProgramFiles%\Master Packager Ltd\Master Packager" -IconPath "%ProgramFiles%\Master Packager Ltd\Master Packager\MasterPackager.exe" -ExpandEnvironmentVariables -As32on64
```

## Checklist

- [x] Did you Clean your script - No environment details, comments are PG-13
- [x] Did you test your script
- [x] If required, did you create, and include a Read Me as outlined in [Community Scripts Read Me](README.MD)

## Notes for PMPC Team

Include any other generic notes for the PMPC review team here.
