### PR TITLE
Incorrectly picking up EXE VLC installs

### DIFF
--- a/Uninstall/Pre-Uninstall/Uninstall VLC Media Player MSI/Uninstall-VLCMediaPlayer-MSI.ps1
+++ b/Uninstall/Pre-Uninstall/Uninstall VLC Media Player MSI/Uninstall-VLCMediaPlayer-MSI.ps1
@@ -495,10 +495,10 @@ $GetInstalledSoftwareSplat = @{
     DisplayName   = $DisplayName
     Architecture  = $Architecture
     HivesToSearch = $HivesToSearch
+    WindowsInstaller = 1
 }
 
 switch ($PSBoundParameters.Keys) {
-    'WindowsInstaller'   { $GetInstalledSoftwareSplat['WindowsInstaller'] = $WindowsInstaller }
     'SystemComponent'    { $GetInstalledSoftwareSplat['SystemComponent'] = $SystemComponent }
     'VersionLessThan'    { $GetInstalledSoftwareSplat['VersionLessThan'] = $VersionLessThan }
     'VersionEqualTo'     { $GetInstalledSoftwareSplat['VersionEqualTo'] = $VersionEqualTo }


### PR DESCRIPTION
Uninstall-VLCMediaPlayer-MSI.ps1 was incorrectly trying to invoke the UninstallString for EXE's if it were detected.