### PR TITLE
Fix betaHighConfidenceTesting assignment in script

### DIFF
--- a/Install/Autopilot/Get-IsInProvisioningMode.ps1
+++ b/Install/Autopilot/Get-IsInProvisioningMode.ps1
@@ -27,7 +27,7 @@ You assume all risks and responsibilities associated with its usage
 #>
 
 # Enable the script to test an undocumented registry value for high confidence testing
-$betaHighConfidenceTesting -eq $false
+$betaHighConfidenceTesting = $false
 
 # Create a PSCustomObject array to store the registry tests
 $registryTests = @()


### PR DESCRIPTION
## Pull Request Type

- [ ] New Script
- [x] Edit Script
- [ ] Repository Improvement

## Brief summary of changes

Changed the first occurance of $betaHighConfidenceTesting to an assignment instead of comparison.
Requirement fails since the comparison outputs "False"

## Describe your Testing

 Tested in autopilot on VM from modified script works to detect oobe.

## Checklist

- [x] Did you Clean your script - No environment details, comments are PG-13
- [x] Did you test your script
- [ ] If required, did you create, and include a Read Me as outlined in [Community Scripts Read Me](README.MD)

## Notes for PMPC Team

